### PR TITLE
[神器672] オーロラブレードの修正

### DIFF
--- a/Asset/data/asset/functions/artifact/0672.aurora_blade/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0672.aurora_blade/give/2.give.mcfunction
@@ -15,7 +15,7 @@
 # 神器の名前 (TextComponentString)
     data modify storage asset:artifact Name set value '{"text":"オーロラブレード","color":"#00ffe2"}'
 # 神器の説明文 (TextComponentString[])
-    data modify storage asset:artifact Lore set value ['{"text":"オーロラの刃を持つ剣","color":"#00cedd"}','{"text":"天使に対して攻撃したとき、","color":"#00acf6"}','{"text":"ダメージが1.5倍になる","color":"#008bff"}']
+    data modify storage asset:artifact Lore set value ['{"text":"オーロラの刃を持つ剣。","color":"#00cedd"}','{"text":"現在MPが70%以上の時、","color":"#00acf6"}','{"text":"ダメージ量+50%","color":"#008bff"}']
 # MP以外の消費物 (TextComponentString) (オプション)
     # data modify storage asset:artifact CostText set value
 # 使用回数 (int) (オプション)

--- a/Asset/data/asset/functions/artifact/0672.aurora_blade/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/0672.aurora_blade/trigger/3.main.mcfunction
@@ -51,7 +51,7 @@
 # 補正functionを実行
     function lib:damage/modifier
 # ダメージを与える
-    execute as @e[type=#lib:living,type=!player,tag=Victim,distance=..6] run function lib:damage/
+    execute as @e[type=#lib:living,tag=Victim,distance=..6] run function lib:damage/
 
 # リセット
     function lib:damage/reset

--- a/Asset/data/asset/functions/artifact/0672.aurora_blade/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/0672.aurora_blade/trigger/3.main.mcfunction
@@ -41,7 +41,7 @@
         # 最低ダメージ設定
             scoreboard players add $RandomDamage Temporary 150
 
-# Argument.Damageに代入 $MPPer > 70 なら1.5倍
+# Argument.Damageに代入 $MPPer >= 70 なら1.5倍
     execute store result storage lib: Argument.Damage float 1 run scoreboard players get $RandomDamage Temporary
     execute if score $MPPer Temporary matches 70.. store result storage lib: Argument.Damage float 1.5 run scoreboard players get $RandomDamage Temporary
 

--- a/Asset/data/asset/functions/artifact/0672.aurora_blade/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/0672.aurora_blade/trigger/3.main.mcfunction
@@ -5,7 +5,7 @@
 # @within function asset:artifact/0672.aurora_blade/trigger/2.check_condition
 
 #> Private
-# @private function asset:artifact/0672.aurora_blade/trigger/**
+# @private
     #declare score_holder $RandomDamage
     #declare score_holder $CalcRandom
 

--- a/Asset/data/asset/functions/artifact/0672.aurora_blade/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/0672.aurora_blade/trigger/3.main.mcfunction
@@ -8,6 +8,18 @@
 # @private
     #declare score_holder $RandomDamage
     #declare score_holder $CalcRandom
+    #declare score_holder $MP
+    #declare score_holder $MPMax
+    #declare score_holder $MPPer
+
+# 現在MPの100倍と最大MPを取得
+    function api:mp/get_current
+    execute store result score $MP Temporary run data get storage api: Return.CurrentMP 100
+    function api:mp/get_max
+    execute store result score $MPMax Temporary run data get storage api: Return.MaxMP
+
+# 現在のMP割合を算出
+    execute store result score $MPPer Temporary run scoreboard players operation $MP Temporary /= $MPMax Temporary
 
 # 基本的な使用時の処理(MP消費や使用回数の処理など)を行う
     function asset:artifact/common/use/mainhand
@@ -28,8 +40,11 @@
             scoreboard players operation $RandomDamage Temporary %= $CalcRandom Temporary
         # 最低ダメージ設定
             scoreboard players add $RandomDamage Temporary 150
-# ダメージセット
+
+# Argument.Damageに代入 $MPPer > 70 なら1.5倍
     execute store result storage lib: Argument.Damage float 1 run scoreboard players get $RandomDamage Temporary
+    execute if score $MPPer Temporary matches 70.. store result storage lib: Argument.Damage float 1.5 run scoreboard players get $RandomDamage Temporary
+
     data modify storage lib: Argument.AttackType set value "Magic"
     data modify storage lib: Argument.ElementType set value "Thunder"
 
@@ -42,3 +57,6 @@
     function lib:damage/reset
     scoreboard players reset $CalcRandom Temporary
     scoreboard players reset $RandomDamage Temporary
+    scoreboard players reset $MP Temporary
+    scoreboard players reset $MPMax Temporary
+    scoreboard players reset $MPPer Temporary

--- a/Asset/data/asset/functions/artifact/0672.aurora_blade/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/0672.aurora_blade/trigger/3.main.mcfunction
@@ -28,13 +28,10 @@
             scoreboard players operation $RandomDamage Temporary %= $CalcRandom Temporary
         # 最低ダメージ設定
             scoreboard players add $RandomDamage Temporary 150
-    #ダメージセット 天使なら1.5倍
-        execute store result storage lib: Argument.Damage float 1 run scoreboard players get $RandomDamage Temporary
-        execute if entity @e[type=#lib:living,tag=Victim,tag=Enemy.Boss,tag=!Uninterferable,distance=..6] store result storage lib: Argument.Damage float 1.5 run scoreboard players get $RandomDamage Temporary
-    # 第一属性
-        data modify storage lib: Argument.AttackType set value "Magic"
-    # 第二属性
-        data modify storage lib: Argument.ElementType set value "Thunder"
+# ダメージセット
+    execute store result storage lib: Argument.Damage float 1 run scoreboard players get $RandomDamage Temporary
+    data modify storage lib: Argument.AttackType set value "Magic"
+    data modify storage lib: Argument.ElementType set value "Thunder"
 
 # 補正functionを実行
     function lib:damage/modifier


### PR DESCRIPTION
・Loreの修正
・ダメージ+50％の条件を"天使を攻撃"から"現在MPが70％以上"に変更
・その他諸々の細かい修正
