### PR TITLE
[神器959] 旋風の鞘の効果を変更

### DIFF
--- a/Asset/data/asset/functions/artifact/0959.whirlwind_scabbard/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0959.whirlwind_scabbard/give/2.give.mcfunction
@@ -15,13 +15,13 @@
 # 神器の名前 (TextComponentString)
     data modify storage asset:artifact Name set value '{"text":"旋風の鞘","color":"#7DFF9B"}'
 # 神器の説明文 (TextComponentString[])
-    data modify storage asset:artifact Lore set value ['{"text":"刀ではなく旋風を収めている鞘","color":"#B0FFC5"}','{"text":"その旋風を抜いた時、前を塞ぐ者を吹き飛ばす。","color":"#B0FFC5"}','{"text":"多く携えるほど旋風は勢いを増す。","color":"#B0FFC5"}']
+    data modify storage asset:artifact Lore set value ['{"text":"刀を抜くと旋風を纏わせる鞘","color":"#B0FFC5"}','{"text":"攻撃時、前を塞ぐ者を吹き飛ばす。","color":"#B0FFC5"}']
 # MP以外の消費物 (TextComponentString) (オプション)
     # data modify storage asset:artifact CostText set value
 # 使用回数 (int) (オプション)
     # data modify storage asset:artifact RemainingCount set value
 # 神器を発動できるスロット (string) Wikiを参照
-    data modify storage asset:artifact Slot set value "hotbar"
+    data modify storage asset:artifact Slot set value "offhand"
 # 神器のトリガー (string) Wikiを参照
     data modify storage asset:artifact Trigger set value "onAttackByMelee"
 # 神器の発動条件 (TextComponentString) (オプション)

--- a/Asset/data/asset/functions/artifact/0959.whirlwind_scabbard/trigger/1.trigger.mcfunction
+++ b/Asset/data/asset/functions/artifact/0959.whirlwind_scabbard/trigger/1.trigger.mcfunction
@@ -5,4 +5,4 @@
 # @within tag/function asset:artifact/**
 
 # storage asset:idの%slot%に装備している神器のIDが入っているので比較し、~/2.check_condition.mcfunctionを実行する
-    execute if data storage asset:context id{hotbar:[959]} run function asset:artifact/0959.whirlwind_scabbard/trigger/2.check_condition
+    execute if data storage asset:context id{offhand:959} run function asset:artifact/0959.whirlwind_scabbard/trigger/2.check_condition

--- a/Asset/data/asset/functions/artifact/0959.whirlwind_scabbard/trigger/2.check_condition.mcfunction
+++ b/Asset/data/asset/functions/artifact/0959.whirlwind_scabbard/trigger/2.check_condition.mcfunction
@@ -7,7 +7,7 @@
 # ID指定する
     data modify storage asset:artifact TargetID set value 959
 # 神器の基本的な条件の確認を行うfunction、成功している場合CanUsedタグが付く
-    function asset:artifact/common/check_condition/hotbar
+    function asset:artifact/common/check_condition/offhand
 # 他にアイテム等確認する場合はここに書く
 
 # CanUsedタグをチェックして3.main.mcfunctionを実行する

--- a/Asset/data/asset/functions/artifact/0959.whirlwind_scabbard/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/0959.whirlwind_scabbard/trigger/3.main.mcfunction
@@ -4,41 +4,18 @@
 #
 # @within function asset:artifact/0959.whirlwind_scabbard/trigger/2.check_condition
 
-#> score_holder
-# @private
-    #declare score_holder $Base
-    #declare score_holder $Count
-    #declare score_holder $Multi
-
 # 基本的な使用時の処理(MP消費や使用回数の処理など)を行う
-    function asset:artifact/common/use/hotbar
-
+    function asset:artifact/common/use/offhand
 # ここから先は神器側の効果の処理を書く
 
 # 演出
     execute at @e[type=#lib:living,type=!player,tag=Victim,distance=..6] run function asset:artifact/0959.whirlwind_scabbard/trigger/vfx
 
-# 個数を取得
-    execute store result score $Count Temporary if data storage asset:context Items.hotbar[{tag:{TSB:{ID:959}}}]
-
-# motionの値の最低値
-    scoreboard players set $Base Temporary 140
-
-# 複数個ある場合の追加する値 (X=40×Count)
-    execute if score $Count Temporary matches 2.. store result score $Multi Temporary run scoreboard players operation $Count Temporary *= $40 Const
-
-# 合算する
-    execute store result storage lib: Argument.VectorMagnitude float 0.01 run scoreboard players operation $Base Temporary += $Multi Temporary
-
-# 対象が天使の場合、本来の値の20%にする
-    execute if entity @e[type=#lib:living,type=!player,tag=Victim,tag=Enemy.Boss,distance=..6] store result storage lib: Argument.VectorMagnitude float 0.002 run scoreboard players get $Base Temporary
-
-# motionLibの実行
+# 実行 対象が天使の場合、本来の値の20%にする
+    data modify storage lib: Argument.VectorMagnitude set value 2
+    execute if entity @e[type=#lib:living,tag=Victim,tag=Enemy.Boss,distance=..6] store result storage lib: Argument.VectorMagnitude float 0.2 run data get storage lib: Argument.VectorMagnitude
     data modify storage lib: Argument.KnockbackResist set value 1b
-    execute as @e[type=#lib:living,type=!player,tag=Victim,distance=..6] at @s rotated as @p[tag=this,distance=..6] rotated ~ -12 run function lib:motion/
+    execute as @e[type=#lib:living,type=!player,tag=Victim,distance=..6] at @s rotated as @p[tag=this,distance=..6] rotated ~ -18 run function lib:motion/
 
 # リセット
-    scoreboard players reset $Base Temporary
-    scoreboard players reset $Count Temporary
-    scoreboard players reset $Multi Temporary
     data remove storage lib: Argument


### PR DESCRIPTION
・対象スロットをhotbarからoffhandに
・複数所持による効果向上を削除
・ノックバック効果を強化