### PR TITLE
ObjectAsset に関する定義を追加

### DIFF
--- a/Asset/data/minecraft/functions/declares.d.mcfunction
+++ b/Asset/data/minecraft/functions/declares.d.mcfunction
@@ -791,6 +791,10 @@
 #declare function asset:object/super.method from https://github.com/ProjectTSB/TheSkyBlessing/blob/master/TheSkyBlessing/data/asset/functions/object/super.method.mcfunction#L1
 
 #> declare
+# @within function asset:object/*/**
+#declare function asset:object/call.m from https://github.com/ProjectTSB/TheSkyBlessing/blob/master/TheSkyBlessing/data/asset/functions/object/call.m.mcfunction#L1
+
+#> declare
 # @within function asset:mob/*/tick/
 #declare function asset:mob/super.tick from https://github.com/ProjectTSB/TheSkyBlessing/blob/master/TheSkyBlessing/data/asset/functions/mob/super.tick.mcfunction#L1
 


### PR DESCRIPTION
Exampleで使用している asset:object/call.m がDeclareされていなかったので追加