### PR TITLE
抽象発射体が1tickに進む距離を指定できるようにした

### DIFF
--- a/Asset/data/asset/functions/object/0001.abstract_projectile/init/.mcfunction
+++ b/Asset/data/asset/functions/object/0001.abstract_projectile/init/.mcfunction
@@ -8,8 +8,6 @@
     execute store result score @s 1.Speed run data get storage asset:context this.Speed
     execute store result score @s 1.Range run data get storage asset:context this.Range
 
-# フィールドのデータから、1tickでどれだけ進むかを設定
-    execute store result score @s 1.MovePerStep run data get storage asset:context this.MovePerStep
 # 上記が設定されてなければ、デフォルト値で0.5にする
     execute unless data storage asset:context this.MovePerStep run data modify storage asset:context this.MovePerStep set value 0.5
 

--- a/Asset/data/asset/functions/object/0001.abstract_projectile/init/.mcfunction
+++ b/Asset/data/asset/functions/object/0001.abstract_projectile/init/.mcfunction
@@ -8,6 +8,11 @@
     execute store result score @s 1.Speed run data get storage asset:context this.Speed
     execute store result score @s 1.Range run data get storage asset:context this.Range
 
+# フィールドのデータから、1tickでどれだけ進むかを設定
+    execute store result score @s 1.MovePerStep run data get storage asset:context this.MovePerStep
+# 上記が設定されてなければ、デフォルト値で0.5にする
+    execute unless data storage asset:context this.MovePerStep run data modify storage asset:context this.MovePerStep set value 0.5
+
 # エラー
     execute unless data storage asset:context this.Speed run tellraw @a [{"storage":"global","nbt":"Prefix.ERROR"},{"text":"速度が設定されていない！"}]
     execute unless data storage asset:context this.Range run tellraw @a [{"storage":"global","nbt":"Prefix.ERROR"},{"text":"飛距離が設定されていない！"}]

--- a/Asset/data/asset/functions/object/0001.abstract_projectile/load.mcfunction
+++ b/Asset/data/asset/functions/object/0001.abstract_projectile/load.mcfunction
@@ -9,3 +9,4 @@
     scoreboard objectives add 1.Recursion dummy
     scoreboard objectives add 1.Range dummy
     scoreboard objectives add 1.Speed dummy
+    scoreboard objectives add 1.MovePerStep dummy

--- a/Asset/data/asset/functions/object/0001.abstract_projectile/load.mcfunction
+++ b/Asset/data/asset/functions/object/0001.abstract_projectile/load.mcfunction
@@ -9,4 +9,3 @@
     scoreboard objectives add 1.Recursion dummy
     scoreboard objectives add 1.Range dummy
     scoreboard objectives add 1.Speed dummy
-    scoreboard objectives add 1.MovePerStep dummy

--- a/Asset/data/asset/functions/object/0001.abstract_projectile/summon/debug.mcfunction
+++ b/Asset/data/asset/functions/object/0001.abstract_projectile/summon/debug.mcfunction
@@ -6,7 +6,7 @@
 # @private
 
 # データ指定
-    data modify storage api: Argument.FieldOverride set value {Speed:10,Range:30}
+    data modify storage api: Argument.FieldOverride set value {Speed:10,Range:30,MovePerStep:0.5}
 
 # 召喚
     data modify storage api: Argument.ID set value 1

--- a/Asset/data/asset/functions/object/0001.abstract_projectile/tick/move.m.mcfunction
+++ b/Asset/data/asset/functions/object/0001.abstract_projectile/tick/move.m.mcfunction
@@ -1,0 +1,7 @@
+#> asset:object/0001.abstract_projectile/tick/move.m
+#
+# TP
+#
+# @within function asset:object/0001.abstract_projectile/tick/recursive
+
+$tp @s ^ ^ ^$(MovePerStep) ~ ~

--- a/Asset/data/asset/functions/object/0001.abstract_projectile/tick/recursive.mcfunction
+++ b/Asset/data/asset/functions/object/0001.abstract_projectile/tick/recursive.mcfunction
@@ -10,7 +10,7 @@
     execute unless entity @s[scores={1.Recursion=1..}] run scoreboard players operation @s 1.Recursion = @s 1.Speed
 
 # 前進
-    execute if entity @s[scores={1.Recursion=1..,1.Range=1..}] run tp @s ^ ^ ^0.5 ~ ~
+    execute if entity @s[scores={1.Recursion=1..,1.Range=1..}] run function asset:object/0001.abstract_projectile/tick/move.m with storage asset:context this
 
 # スコア減算
     scoreboard players remove @s 1.Recursion 1


### PR DESCRIPTION
0.5刻みだと早すぎるとき用。

- RangeやSpeedを指定するのと同じように、MovePerTickに1tickに進む距離を指定できるようにしました。
- 低弾速の弾を作るのに便利だと思います。