### PR TITLE
:balance_scale: [神器1106] 虹色キャンディの調整

### DIFF
--- a/Asset/data/asset/functions/artifact/1106.rainbow_candy/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/1106.rainbow_candy/give/2.give.mcfunction
@@ -19,7 +19,7 @@
 # MP以外の消費物 (TextComponentString) (オプション)
     # data modify storage asset:artifact CostText set value
 # 使用回数 (int) (オプション)
-    data modify storage asset:artifact RemainingCount set value 77
+    data modify storage asset:artifact RemainingCount set value 7
 # 神器を発動できるスロット (string) Wikiを参照
     data modify storage asset:artifact Slot set value "auto"
 # 神器のトリガー (string) Wikiを参照

--- a/Asset/data/asset/functions/artifact/1106.rainbow_candy/register.mcfunction
+++ b/Asset/data/asset/functions/artifact/1106.rainbow_candy/register.mcfunction
@@ -1,7 +1,0 @@
-#> asset:artifact/1106.rainbow_candy/register
-#
-# 神器プールへの登録処理
-#
-# @within tag/function asset:artifact/register
-
-data modify storage asset:artifact RarityRegistry[1] append value [1106]

--- a/Asset/data/asset/tags/functions/artifact/register.json
+++ b/Asset/data/asset/tags/functions/artifact/register.json
@@ -252,7 +252,6 @@
         "asset:artifact/1088.purifying_hydrangea/register",
         "asset:artifact/1089.antimatter_gatling_rifle/register",
         "asset:artifact/1098.mirror_piece_of_bygone_days/register",
-        "asset:artifact/1106.rainbow_candy/register",
         "asset:artifact/1108.white_lily_of_priestess/register"
     ]
 }


### PR DESCRIPTION
トリック・アンド・トリートでgiveされるように仕様を変えるため
・加工機から出ないように
・使用回数を減らした