### PR TITLE
🍱 [Mob423] エッジメイジを作成

### DIFF
--- a/Asset/data/asset/functions/mob/0423.edge_mage/attack/.mcfunction
+++ b/Asset/data/asset/functions/mob/0423.edge_mage/attack/.mcfunction
@@ -1,0 +1,34 @@
+#> asset:mob/0423.edge_mage/attack/
+#
+# Mobの攻撃時の処理
+#
+# @within function asset:mob/alias/423/attack
+
+# バニラの攻撃じゃなかったら return
+    execute unless data storage asset:context Attack{IsVanilla:true} run return fail
+
+# 乱数を取る
+    execute store result score @s Temporary run random value 0..2
+
+# 共通の演出
+    playsound minecraft:item.trident.throw hostile @a ~ ~ ~ 1 1.2
+    playsound minecraft:entity.witch.throw hostile @a ~ ~ ~ 1 0.5
+
+# 攻撃
+    # ダメージ量
+        data modify storage lib: Argument.Damage set value 40.0f
+    # 第一属性
+        data modify storage lib: Argument.AttackType set value "Magic"
+    # 第二属性を設定したり演出変えたり
+        execute if score @s Temporary matches 0 at @p[tag=Victim,distance=..8] run function asset:mob/0423.edge_mage/attack/fire
+        execute if score @s Temporary matches 1 at @p[tag=Victim,distance=..8] run function asset:mob/0423.edge_mage/attack/water
+        execute if score @s Temporary matches 2 at @p[tag=Victim,distance=..8] run function asset:mob/0423.edge_mage/attack/thunder
+    # 補正functionを実行
+        function lib:damage/modifier
+    # ダメージを与える
+        execute as @p[tag=Victim,distance=..8] at @s run function lib:damage/
+    # リセット
+        function lib:damage/reset
+
+# リセット
+    scoreboard players reset @s Temporary

--- a/Asset/data/asset/functions/mob/0423.edge_mage/attack/fire.mcfunction
+++ b/Asset/data/asset/functions/mob/0423.edge_mage/attack/fire.mcfunction
@@ -1,0 +1,13 @@
+#> asset:mob/0423.edge_mage/attack/fire
+#
+# 火
+#
+# @within function asset:mob/0423.edge_mage/attack/
+
+# 属性セット
+    data modify storage lib: Argument.ElementType set value "Fire"
+
+# 演出
+    particle minecraft:flame ~ ~1 ~ 0.3 0.5 0.3 0.01 10
+    particle minecraft:dust 1 0.5 0 1 ~ ~1 ~ 0.2 0.5 0.2 0.01 20
+    playsound minecraft:entity.blaze.shoot hostile @a ~ ~ ~ 1 1.5

--- a/Asset/data/asset/functions/mob/0423.edge_mage/attack/thunder.mcfunction
+++ b/Asset/data/asset/functions/mob/0423.edge_mage/attack/thunder.mcfunction
@@ -1,0 +1,13 @@
+#> asset:mob/0423.edge_mage/attack/thunder
+#
+#
+#
+# @within function asset:mob/0423.edge_mage/attack/
+
+# 属性セット
+    data modify storage lib: Argument.ElementType set value "Thunder"
+
+# 演出
+    particle minecraft:electric_spark ~ ~1 ~ 0.1 0.5 0.1 1 10
+    particle minecraft:dust 1 1 0.25 1 ~ ~1 ~ 0.2 0.5 0.2 0.01 20
+    playsound minecraft:entity.firework_rocket.twinkle hostile @a ~ ~ ~ 1 1.5

--- a/Asset/data/asset/functions/mob/0423.edge_mage/attack/water.mcfunction
+++ b/Asset/data/asset/functions/mob/0423.edge_mage/attack/water.mcfunction
@@ -1,0 +1,13 @@
+#> asset:mob/0423.edge_mage/attack/water
+#
+#
+#
+# @within function asset:mob/0423.edge_mage/attack/
+
+# 属性セット
+    data modify storage lib: Argument.ElementType set value "Water"
+
+# 演出
+    particle minecraft:bubble_pop ~ ~1 ~ 0.3 0.5 0.3 0.01 10
+    particle minecraft:dust 0 0.5 1 1 ~ ~1 ~ 0.2 0.5 0.2 0.01 20
+    playsound minecraft:entity.generic.swim hostile @a ~ ~ ~ 1 0.7

--- a/Asset/data/asset/functions/mob/0423.edge_mage/death/.mcfunction
+++ b/Asset/data/asset/functions/mob/0423.edge_mage/death/.mcfunction
@@ -1,0 +1,9 @@
+#> asset:mob/0423.edge_mage/death/
+#
+# Mobの死亡時の処理
+#
+# @within function asset:mob/alias/423/death
+
+# 演出
+    playsound minecraft:entity.vex.ambient hostile @a ~ ~ ~ 1 0.7
+    playsound minecraft:entity.phantom.hurt hostile @a ~ ~ ~ 1 0.5

--- a/Asset/data/asset/functions/mob/0423.edge_mage/hurt/.mcfunction
+++ b/Asset/data/asset/functions/mob/0423.edge_mage/hurt/.mcfunction
@@ -1,0 +1,9 @@
+#> asset:mob/0423.edge_mage/hurt/
+#
+# Mobのダメージ時の処理
+#
+# @within function asset:mob/alias/423/hurt
+
+# サウンド
+    playsound minecraft:entity.vex.hurt hostile @a ~ ~ ~ 1 0.5
+    playsound minecraft:entity.vex.hurt hostile @a ~ ~ ~ 1 0.7

--- a/Asset/data/asset/functions/mob/0423.edge_mage/register.mcfunction
+++ b/Asset/data/asset/functions/mob/0423.edge_mage/register.mcfunction
@@ -1,0 +1,55 @@
+#> asset:mob/0423.edge_mage/register
+#
+# Mobのデータを指定
+#
+# @within function asset:mob/alias/423/register
+
+# 他のモブに継承されることを許可するか (boolean) (オプション)
+    # data modify storage asset:mob ExtendsSafe set value
+# 継承されることを前提とした、抽象的なモブであるかどうか(boolean)
+    data modify storage asset:mob IsAbstract set value false
+# ID (int)
+    data modify storage asset:mob ID set value 423
+# Type (string) Wikiを参照
+    data modify storage asset:mob Type set value "Enemy"
+# 干渉可能か否か (boolean)
+    data modify storage asset:mob Interferable set value true
+# 名前 (TextComponentString) (オプション)
+    data modify storage asset:mob Name set value '{"text":"エッジメイジ","color":"white"}'
+# Mobの説明文 (TextComponentString[]) (オプション)
+    data modify storage asset:mob Lore set value ['{"text":"魔力を込めた剣で斬りかかってくる、メイジ一派の前線役。","color":"white"}','{"text":"一応魔法使いなので、魔法攻撃には耐性があるが、物理攻撃には弱い。","color":"white"}']
+# 武器
+    # メインハンド (Compound(Item)) (オプション)
+        data modify storage asset:mob Weapon.Mainhand set value {id:"minecraft:stick",Count:1b,tag:{CustomModelData:57,Enchantments:[{id:"minecraft:knockback",lvl:1s}]}}
+    # オフハンド (Compound(Item)) (オプション)
+        # data modify storage asset:mob Weapon.Offhand set value
+# 武器ドロップ率 ([float, float]) (オプション)
+    # data modify storage asset:mob WeaponDropChances set value
+# 防具
+    # 頭 (Compound(Item)) (オプション)
+        data modify storage asset:mob Armor.Head set value {id:"minecraft:stick",Count:1b,tag:{CustomModelData:20067}}
+    # 胴 (Compound(Item)) (オプション)
+        data modify storage asset:mob Armor.Chest set value {id:"minecraft:iron_chestplate",Count:1b}
+# 防具ドロップ率 ([float, float]) (オプション)
+    # data modify storage asset:mob ArmorDropChances set value
+# 体力 (double) (オプション)
+    data modify storage asset:mob Health set value 3200
+# 攻撃力 (double) (オプション)
+    # data modify storage asset:mob AttackDamage set value 1d
+# 防御力 (double) (オプション) // 被ダメージがある程度大きい場合1ptにつき0.8%カット、小さい場合1ptにつき約4%カット 20pt以上は頭打ち
+    data modify storage asset:mob Defense set value -3
+# 移動速度 (double) (オプション)
+    data modify storage asset:mob Speed set value 0.25d
+# 属性倍率 // 1.0fで100% 最低でも25%は軽減されずに入る
+    # 物理倍率 (float) (オプション)
+        data modify storage asset:mob Resist.Physical set value 1.2
+    # 魔法倍率 (float) (オプション)
+        data modify storage asset:mob Resist.Magic set value 0.5
+    # 火倍率 (float) (オプション)
+        data modify storage asset:mob Resist.Fire set value 1
+    # 水倍率 (float) (オプション)
+        data modify storage asset:mob Resist.Water set value 1
+    # 雷倍率 (float) (オプション)
+        data modify storage asset:mob Resist.Thunder set value 1
+# フィールド
+    # data modify storage asset:mob Field.myValue set value

--- a/Asset/data/asset/functions/mob/0423.edge_mage/register.mcfunction
+++ b/Asset/data/asset/functions/mob/0423.edge_mage/register.mcfunction
@@ -33,7 +33,7 @@
 # 防具ドロップ率 ([float, float]) (オプション)
     # data modify storage asset:mob ArmorDropChances set value
 # 体力 (double) (オプション)
-    data modify storage asset:mob Health set value 3200
+    data modify storage asset:mob Health set value 3000
 # 攻撃力 (double) (オプション)
     # data modify storage asset:mob AttackDamage set value 1d
 # 防御力 (double) (オプション) // 被ダメージがある程度大きい場合1ptにつき0.8%カット、小さい場合1ptにつき約4%カット 20pt以上は頭打ち

--- a/Asset/data/asset/functions/mob/0423.edge_mage/summon/.mcfunction
+++ b/Asset/data/asset/functions/mob/0423.edge_mage/summon/.mcfunction
@@ -1,0 +1,8 @@
+#> asset:mob/0423.edge_mage/summon/
+#
+# Object召喚処理の呼び出し時に実行されるfunction
+#
+# @within asset:mob/alias/423/summon
+
+# 元となるEntityを召喚する
+    summon zombie ~ ~ ~ {Tags:["MobInit","AlwaysInvisible"],Silent:1b,DeathLootTable:"minecraft:empty"}

--- a/Asset/data/asset/functions/mob/0423.edge_mage/tick/.mcfunction
+++ b/Asset/data/asset/functions/mob/0423.edge_mage/tick/.mcfunction
@@ -1,0 +1,8 @@
+#> asset:mob/0423.edge_mage/tick/
+#
+# Mobのtick時の処理
+#
+# @within asset:mob/alias/423/tick
+
+# パーティクル
+    particle minecraft:falling_dust iron_block ~ ~1 ~ 0.1 0 0.1 0 1

--- a/Asset/data/asset/functions/mob/alias/423/attack.mcfunction
+++ b/Asset/data/asset/functions/mob/alias/423/attack.mcfunction
@@ -1,0 +1,8 @@
+#> asset:mob/alias/423/attack
+#
+# Mobの攻撃時の処理のエイリアス
+#
+# @within asset_manager:mob/triggers/attack/attack.m
+
+# 本来の処理を呼び出す
+   function asset:mob/0423.edge_mage/attack/

--- a/Asset/data/asset/functions/mob/alias/423/death.mcfunction
+++ b/Asset/data/asset/functions/mob/alias/423/death.mcfunction
@@ -1,0 +1,8 @@
+#> asset:mob/alias/423/death
+#
+# Mobの死亡時の処理のエイリアス
+#
+# @within asset_manager:mob/triggers/death/death.m
+
+# 本来の処理を呼び出す
+   function asset:mob/0423.edge_mage/death/

--- a/Asset/data/asset/functions/mob/alias/423/hurt.mcfunction
+++ b/Asset/data/asset/functions/mob/alias/423/hurt.mcfunction
@@ -1,0 +1,8 @@
+#> asset:mob/alias/423/hurt
+#
+# Mobのダメージ時の処理のエイリアス
+#
+# @within asset_manager:mob/triggers/hurt/hurt.m
+
+# 本来の処理を呼び出す
+   function asset:mob/0423.edge_mage/hurt/

--- a/Asset/data/asset/functions/mob/alias/423/register.mcfunction
+++ b/Asset/data/asset/functions/mob/alias/423/register.mcfunction
@@ -1,0 +1,8 @@
+#> asset:mob/alias/423/register
+#
+# Mobのデータ指定処理のエイリアス
+#
+# @within asset_manager:mob/triggers/summon/register.m
+
+# 元の登録処理を呼び出す
+   function asset:mob/0423.edge_mage/register

--- a/Asset/data/asset/functions/mob/alias/423/summon.mcfunction
+++ b/Asset/data/asset/functions/mob/alias/423/summon.mcfunction
@@ -1,0 +1,8 @@
+#> asset:mob/alias/423/summon
+#
+# Mob召喚処理のエイリアス
+#
+# @within asset_manager:mob/triggers/summon/summon.m
+
+# 本来の処理を呼び出す
+   function asset:mob/0423.edge_mage/summon/

--- a/Asset/data/asset/functions/mob/alias/423/tick.mcfunction
+++ b/Asset/data/asset/functions/mob/alias/423/tick.mcfunction
@@ -1,0 +1,8 @@
+#> asset:mob/alias/423/tick
+#
+# Tick時処理のエイリアス
+#
+# @within asset_manager:mob/triggers/tick/tick.m
+
+# 元のTick処理を呼び出す
+   function asset:mob/0423.edge_mage/tick/


### PR DESCRIPTION
メイジ島に出てくる敵、ほとんど全員が特殊攻撃持ちで忙しね～…と感じたので、にぎやかし担当として作りました。いつものメイジをエリート枠とするなら、コイツらはそれといっしょに現れるザコです。
近接タイプですが何気にメイジ系と耐性が同じで、強力な魔法耐性を持ちますが、物理攻撃に弱いです。
他の島にも出せそうですが、妙な耐性と攻撃属性を持っているのがネックになりそう。