### PR TITLE
:adhesive_bandage: [Object2168] レーザーの消失時、マーカーが残りっぱなしだったのを修正

### DIFF
--- a/Asset/data/asset/functions/object/2168.general_long_laser/tick/.mcfunction
+++ b/Asset/data/asset/functions/object/2168.general_long_laser/tick/.mcfunction
@@ -52,4 +52,5 @@
     execute if score @s General.Object.Tick = @s 2168.DisppearTick run function asset:object/2168.general_long_laser/tick/transform/disappear
 
 # 消滅処理
+    execute if score @s General.Object.Tick > @s 2168.LifeTime on passengers run kill @s
     execute if score @s General.Object.Tick > @s 2168.LifeTime run kill @s


### PR DESCRIPTION
回転用にMarkerを自身の上に乗せているオブジェクトなのですが、消失時にそのマーカーを消し忘れていました