### PR TITLE
⚖️ [Mob372] ツタンカーメンのレーザー攻撃の判定周りの調整

### DIFF
--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/laser/shoot/summon.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/laser/shoot/summon.mcfunction
@@ -6,7 +6,7 @@
 
 # オブジェクト召喚
     data modify storage api: Argument.ID set value 2168
-    data modify storage api: Argument.FieldOverride set value {Scale:[0.25f,60f,0.25f],Color:65535,DisappearInterpolation:2,LifeTime:10}
+    data modify storage api: Argument.FieldOverride set value {Scale:[0.25f,30f,0.25f],Color:65535,DisappearInterpolation:2,LifeTime:10}
     function api:object/summon
 
 # パーティクル
@@ -16,9 +16,9 @@
 # 立方体範囲内のプレイヤーにtag付け
     data modify storage lib: args.dx set value 0.5
     data modify storage lib: args.dy set value 1.5
-    data modify storage lib: args.dz set value 60.0
+    data modify storage lib: args.dz set value 30.0
     data modify storage lib: args.selector set value "@a[tag=!PlayerShouldInvulnerable,distance=..64]"
-    execute positioned ^ ^-1 ^30 run function lib:rotatable_dxyz/m with storage lib: args
+    execute positioned ^ ^-1 ^15 run function lib:rotatable_dxyz/m with storage lib: args
 
 # ダメージを与える
     # データ設定

--- a/Asset/data/asset/functions/object/2091.hyper_laser_manager/tick/summon_laser.mcfunction
+++ b/Asset/data/asset/functions/object/2091.hyper_laser_manager/tick/summon_laser.mcfunction
@@ -5,5 +5,5 @@
 # @within function asset:object/2091.hyper_laser_manager/tick/
 
 data modify storage api: Argument.ID set value 2168
-data modify storage api: Argument.FieldOverride set value {Scale:[7f,60f,7f],Color:9763071,DisappearInterpolation:3,LifeTime:15}
+data modify storage api: Argument.FieldOverride set value {Scale:[7f,30f,7f],Color:9763071,DisappearInterpolation:3,LifeTime:15}
 function api:object/summon


### PR DESCRIPTION
- ツタンカーメン以外での使用も想定していたレーザーのオブジェクトですが、Y軸スケールを2で1ブロックから1で1ブロックになるように見た目を調整しました。リソースパック側の変更なので、オブジェクト側には変更が入っていません。
- この変更により、このオブジェクトを使っているツタンカーメンの一部攻撃の判定が見た目と一致しなくなったので、その修正です