### PR TITLE
【Mob338】双子ボスバーなど修正

### DIFF
--- a/Asset/data/asset/functions/mob/0338.corundum_twins/tick/app/skill/event_handler/01_crossfire/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0338.corundum_twins/tick/app/skill/event_handler/01_crossfire/1.main.mcfunction
@@ -6,7 +6,7 @@
 # @within function asset:mob/0338.corundum_twins/tick/app/skill/event_handler/1.switch
 
 # 集合位置の決定
-    execute if score @s 9E.SkillTimer matches 1 at @a[tag=!PlayerShouldInvulnerable,sort=random,limit=1] rotated ~ 0 run summon area_effect_cloud ^ ^1 ^5 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9E.Temp.Target.Aec.0"]}
+    execute if score @s 9E.SkillTimer matches 1 at @a[tag=!PlayerShouldInvulnerable,distance=..60,sort=random,limit=1] rotated ~ 0 run summon area_effect_cloud ^ ^1 ^5 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9E.Temp.Target.Aec.0"]}
     execute if score @s 9E.SkillTimer matches 1 as @e[type=area_effect_cloud,tag=9E.Temp.Target.Aec.0] at @s facing entity @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] feet run tp @s ~ ~ ~ ~ 0
     execute if score @s 9E.SkillTimer matches 1 at @e[type=area_effect_cloud,tag=9E.Temp.Target.Aec.0,limit=1] run summon area_effect_cloud ^-1.8 ^ ^ {CustomNameVisible:0b,Particle:"block air",Duration:17,Tags:["Object","9E.Temp.Target.Aec.0","9F.Temp.Target.Aec.0"]}
     execute if score @s 9E.SkillTimer matches 1 at @e[type=area_effect_cloud,tag=9E.Temp.Target.Aec.0,limit=1] run summon area_effect_cloud ^1.8 ^ ^ {CustomNameVisible:0b,Particle:"block air",Duration:17,Tags:["Object","9E.Temp.Target.Aec.0","9G.Temp.Target.Aec.0"]}

--- a/Asset/data/asset/functions/mob/0338.corundum_twins/tick/app/skill/event_handler/02_throw/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0338.corundum_twins/tick/app/skill/event_handler/02_throw/1.main.mcfunction
@@ -6,7 +6,7 @@
 # @within function asset:mob/0338.corundum_twins/tick/app/skill/event_handler/1.switch
 
 # 集合位置の決定
-    execute if score @s 9E.SkillTimer matches 1 at @a[tag=!PlayerShouldInvulnerable,sort=random,limit=1] rotated ~ 0 run summon area_effect_cloud ^ ^1 ^12 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9E.Temp.Target.Aec.0"]}
+    execute if score @s 9E.SkillTimer matches 1 at @a[tag=!PlayerShouldInvulnerable,distance=..60,sort=random,limit=1] rotated ~ 0 run summon area_effect_cloud ^ ^1 ^12 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9E.Temp.Target.Aec.0"]}
     execute if score @s 9E.SkillTimer matches 1 as @e[type=area_effect_cloud,tag=9E.Temp.Target.Aec.0] at @s facing entity @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] feet run tp @s ~ ~ ~ ~ 0
     execute if score @s 9E.SkillTimer matches 1 at @e[type=area_effect_cloud,tag=9E.Temp.Target.Aec.0,limit=1] run summon area_effect_cloud ^1 ^ ^ {CustomNameVisible:0b,Particle:"block air",Duration:17,Tags:["Object","9E.Temp.Target.Aec.0","9F.Temp.Target.Aec.0"]}
     execute if score @s 9E.SkillTimer matches 1 at @e[type=area_effect_cloud,tag=9E.Temp.Target.Aec.0,limit=1] run summon area_effect_cloud ^-1 ^ ^ {CustomNameVisible:0b,Particle:"block air",Duration:17,Tags:["Object","9E.Temp.Target.Aec.0","9G.Temp.Target.Aec.0"]}

--- a/Asset/data/asset/functions/mob/0338.corundum_twins/tick/app/skill/event_handler/03_launcher/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0338.corundum_twins/tick/app/skill/event_handler/03_launcher/1.main.mcfunction
@@ -6,7 +6,7 @@
 # @within function asset:mob/0338.corundum_twins/tick/app/skill/event_handler/1.switch
 
 # 集合位置の決定
-    execute if score @s 9E.SkillTimer matches 1 at @a[tag=!PlayerShouldInvulnerable,sort=random,limit=1] rotated ~ 0 run summon area_effect_cloud ^ ^1 ^7 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9E.Temp.Target.Aec.0"]}
+    execute if score @s 9E.SkillTimer matches 1 at @a[tag=!PlayerShouldInvulnerable,distance=..60,sort=random,limit=1] rotated ~ 0 run summon area_effect_cloud ^ ^1 ^7 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9E.Temp.Target.Aec.0"]}
     execute if score @s 9E.SkillTimer matches 1 as @e[type=area_effect_cloud,tag=9E.Temp.Target.Aec.0] at @s facing entity @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] feet run tp @s ~ ~ ~ ~ 0
     execute if score @s 9E.SkillTimer matches 1 at @e[type=area_effect_cloud,tag=9E.Temp.Target.Aec.0,limit=1] run summon area_effect_cloud ^-1.2 ^ ^-0.5 {CustomNameVisible:0b,Particle:"block air",Duration:17,Tags:["Object","9E.Temp.Target.Aec.0","9F.Temp.Target.Aec.0"]}
     execute if score @s 9E.SkillTimer matches 1 at @e[type=area_effect_cloud,tag=9E.Temp.Target.Aec.0,limit=1] run summon area_effect_cloud ^1.2 ^ ^0.5 {CustomNameVisible:0b,Particle:"block air",Duration:17,Tags:["Object","9E.Temp.Target.Aec.0","9G.Temp.Target.Aec.0"]}

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/init/.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/init/.mcfunction
@@ -28,5 +28,10 @@
 # 移動
     execute at @s run tp @s ~ ~-100 ~
 
+# bossbar消去
+    execute store result storage asset:temp 9F.MobUUID int 1 run scoreboard players get @s MobUUID
+    function asset:mob/0339.twins_sapphiel/init/remove_bossbar.m with storage asset:temp 9F
+    data remove storage asset:temp 9F
+
 # HP共有
     scoreboard players operation @s ForwardTargetMobUUID = @e[type=slime,tag=9E.Root,sort=nearest,limit=1] MobUUID

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/init/remove_bossbar.m.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/init/remove_bossbar.m.mcfunction
@@ -1,0 +1,5 @@
+#> asset:mob/0339.twins_sapphiel/init/remove_bossbar.m
+# @within asset:mob/0339.twins_sapphiel/init/
+
+# bossbar消去
+    $bossbar remove asset:angel$(MobUUID)

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/05_hg_riderkick/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/05_hg_riderkick/1.main.mcfunction
@@ -15,7 +15,7 @@
     execute if score @s 9F.AnimationTimer matches 30..38 at @s positioned ^ ^ ^0.3 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
     execute if score @s 9F.AnimationTimer matches 39..45 at @s positioned ^ ^ ^0.1 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
     # ベクトル計算移動
-        execute if score @s 9F.AnimationTimer matches 19 at @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] run summon area_effect_cloud ^ ^0.1 ^-1 {CustomNameVisible:0b,Particle:"block air",Duration:6,Tags:["Object","9F.Temp.Target.Aec.0"]}
+        execute if score @s 9F.AnimationTimer matches 19 at @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] run summon area_effect_cloud ^ ^0.1 ^-1 {CustomNameVisible:0b,Particle:"block air",Duration:6,Tags:["Object","9F.Temp.Target.Aec.0"]}
         execute if score @s 9F.AnimationTimer matches 20 if entity @e[type=area_effect_cloud,tag=9F.Temp.Target.Aec.0] run function asset:mob/0339.twins_sapphiel/tick/app/skill/event_handler/05_hg_riderkick/4.calc_vector
         execute if score @s 9F.AnimationTimer matches 21..29 run function asset:mob/0339.twins_sapphiel/app/general/4.teleport_using_vector
 
@@ -30,7 +30,7 @@
     execute if score @s 9F.AnimationTimer matches 30 run particle explosion ~ ~ ~ 0 0 0 0 1
     execute if score @s 9F.AnimationTimer matches 30 run particle campfire_cosy_smoke ~ ~ ~ 0.1 0.1 0.1 0.03 10
     execute if score @s 9F.AnimationTimer matches 30..35 run playsound block.grass.step hostile @a ~ ~ ~ 1 1
-    execute if score @s 9F.AnimationTimer matches 30..35 at @s run particle block sea_lantern ~ ~0.1 ~ 0.2 0 0.2 1 3 
+    execute if score @s 9F.AnimationTimer matches 30..35 at @s run particle block sea_lantern ~ ~0.1 ~ 0.2 0 0.2 1 3
     execute if score @s 9F.AnimationTimer matches 36 run playsound entity.ender_dragon.flap hostile @a ~ ~ ~ 1 1.2
     execute if score @s 9F.AnimationTimer matches 30 rotated ~ -90 positioned ~ ~0.5 ~ run function asset:mob/0339.twins_sapphiel/tick/app/skill/event_handler/05_hg_riderkick/6.2.particle_circle_single
 

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/06_hg_punch/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/06_hg_punch/1.main.mcfunction
@@ -13,9 +13,9 @@
     execute if score @s 9F.AnimationTimer matches 1..8 at @s positioned ^ ^ ^-0.1 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
     execute if score @s 9F.AnimationTimer matches 66..76 at @s positioned ^ ^ ^-0.4 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
     # ベクトル計算移動
-        execute if score @s 9F.AnimationTimer matches 40 at @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] run summon area_effect_cloud ^ ^0.1 ^-1 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9F.Temp.Target.Aec.0"]}
+        execute if score @s 9F.AnimationTimer matches 40 at @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] run summon area_effect_cloud ^ ^0.1 ^-1 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9F.Temp.Target.Aec.0"]}
         execute if score @s 9F.AnimationTimer matches 40 if entity @e[type=area_effect_cloud,tag=9F.Temp.Target.Aec.0] at @s run function asset:mob/0339.twins_sapphiel/tick/app/skill/event_handler/06_hg_punch/4.calc_vector_0
-        execute if score @s 9F.AnimationTimer matches 47 at @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] run summon area_effect_cloud ^ ^0.1 ^-1 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9F.Temp.Target.Aec.0"]}
+        execute if score @s 9F.AnimationTimer matches 47 at @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] run summon area_effect_cloud ^ ^0.1 ^-1 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9F.Temp.Target.Aec.0"]}
         execute if score @s 9F.AnimationTimer matches 47 if entity @e[type=area_effect_cloud,tag=9F.Temp.Target.Aec.0] at @s run function asset:mob/0339.twins_sapphiel/tick/app/skill/event_handler/06_hg_punch/4.calc_vector_1
         execute if score @s 9F.AnimationTimer matches 41..49 unless entity @a[tag=!PlayerShouldInvulnerable,distance=..2] at @s run function asset:mob/0339.twins_sapphiel/app/general/4.teleport_using_vector
 

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/07_1_hg_warpshot/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/07_1_hg_warpshot/1.main.mcfunction
@@ -10,7 +10,7 @@
 
 # 移動
     execute if score @s 9F.AnimationTimer matches 1..40 run function asset:mob/0339.twins_sapphiel/app/general/2.rotate
-    
+
 # 演出
     execute if score @s 9F.AnimationTimer matches 13 run playsound entity.evoker.cast_spell hostile @a ~ ~ ~ 2 1.2
     execute if score @s 9F.AnimationTimer matches 30 run playsound entity.ender_dragon.flap hostile @a ~ ~ ~ 2 1.2
@@ -22,9 +22,9 @@
     execute if score @s 9F.AnimationTimer matches 58 positioned ^0.5 ^1 ^0.8 rotated ~-30 ~ run function asset:mob/0339.twins_sapphiel/tick/app/skill/event_handler/07_1_hg_warpshot/4.particle_shot
 
 # ワープポイント設置
-    execute if score @s 9F.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] rotated ~ 0 run summon area_effect_cloud ^-7 ^3 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:82,Tags:["Object","9F.Temp.Target.Warp","9F.Temp.Target.Warp.0"]}
-    execute if score @s 9F.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] rotated ~ 0 run summon area_effect_cloud ^ ^5.5 ^9 {CustomNameVisible:0b,Particle:"block air",Duration:82,Tags:["Object","9F.Temp.Target.Warp","9F.Temp.Target.Warp.1"]}
-    execute if score @s 9F.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] rotated ~ 0 run summon area_effect_cloud ^7 ^3 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:82,Tags:["Object","9F.Temp.Target.Warp","9F.Temp.Target.Warp.2"]}
+    execute if score @s 9F.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] rotated ~ 0 run summon area_effect_cloud ^-7 ^3 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:82,Tags:["Object","9F.Temp.Target.Warp","9F.Temp.Target.Warp.0"]}
+    execute if score @s 9F.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] rotated ~ 0 run summon area_effect_cloud ^ ^5.5 ^9 {CustomNameVisible:0b,Particle:"block air",Duration:82,Tags:["Object","9F.Temp.Target.Warp","9F.Temp.Target.Warp.1"]}
+    execute if score @s 9F.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] rotated ~ 0 run summon area_effect_cloud ^7 ^3 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:82,Tags:["Object","9F.Temp.Target.Warp","9F.Temp.Target.Warp.2"]}
 
 # 攻撃
     execute if score @s 9F.AnimationTimer matches 54 at @e[type=area_effect_cloud,tag=9F.Temp.Target.Warp.1,sort=nearest,limit=1] at @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] run summon area_effect_cloud ~ ~1 ~ {CustomNameVisible:0b,Particle:"block air",Duration:7,Tags:["Object","9F.Temp.Target.Aec.0"]}

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/07_2_hg_heeloff/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/07_2_hg_heeloff/1.main.mcfunction
@@ -13,9 +13,9 @@
     execute if score @s 9F.AnimationTimer matches 6..20 run function asset:mob/0339.twins_sapphiel/app/general/2.rotate
     execute if score @s 9F.AnimationTimer matches 15..23 at @s positioned ^ ^0.1 ^0.4 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
     # ベクトル計算移動
-        execute if score @s 9F.AnimationTimer matches 15 positioned as @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] run summon area_effect_cloud ^ ^4 ^-6 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9F.Temp.Target.Aec.0"]}
+        execute if score @s 9F.AnimationTimer matches 15 positioned as @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] run summon area_effect_cloud ^ ^4 ^-6 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9F.Temp.Target.Aec.0"]}
         execute if score @s 9F.AnimationTimer matches 15 if entity @e[type=area_effect_cloud,tag=9F.Temp.Target.Aec.0] at @s run function asset:mob/0339.twins_sapphiel/tick/app/skill/event_handler/07_2_hg_heeloff/4.1.calc_vector_0
-        execute if score @s 9F.AnimationTimer matches 23 positioned as @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] run summon area_effect_cloud ^ ^0.1 ^-1 {CustomNameVisible:0b,Particle:"block air",Duration:6,Tags:["Object","9F.Temp.Target.Aec.0"]}
+        execute if score @s 9F.AnimationTimer matches 23 positioned as @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] run summon area_effect_cloud ^ ^0.1 ^-1 {CustomNameVisible:0b,Particle:"block air",Duration:6,Tags:["Object","9F.Temp.Target.Aec.0"]}
         execute if score @s 9F.AnimationTimer matches 28 if entity @e[type=area_effect_cloud,tag=9F.Temp.Target.Aec.0] at @s run function asset:mob/0339.twins_sapphiel/tick/app/skill/event_handler/07_2_hg_heeloff/4.2.calc_vector_1
         execute if score @s 9F.AnimationTimer matches 15..22 run function asset:mob/0339.twins_sapphiel/app/general/4.teleport_using_vector
         execute if score @s 9F.AnimationTimer matches 28..33 run function asset:mob/0339.twins_sapphiel/app/general/4.teleport_using_vector

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/init/.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/init/.mcfunction
@@ -29,5 +29,10 @@ execute positioned ~ ~100 ~ rotated ~ 0 run function animated_java:twins_rubiel/
 # 移動
     execute at @s run tp @s ~ ~-100 ~
 
+# bossbar消去
+    execute store result storage asset:temp 9G.MobUUID int 1 run scoreboard players get @s MobUUID
+    function asset:mob/0340.twins_rubiel/init/remove_bossbar.m with storage asset:temp 9G
+    data remove storage asset:temp 9G
+
 # HP共有
     scoreboard players operation @s ForwardTargetMobUUID = @e[type=slime,tag=9E.Root,sort=nearest,limit=1] MobUUID

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/init/remove_bossbar.m.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/init/remove_bossbar.m.mcfunction
@@ -1,0 +1,5 @@
+#> asset:mob/0340.twins_rubiel/init/remove_bossbar.m
+# @within asset:mob/0340.twins_rubiel/init/
+
+# bossbar消去
+    $bossbar remove asset:angel$(MobUUID)

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_2_kt_movetospear/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_2_kt_movetospear/1.main.mcfunction
@@ -20,9 +20,9 @@
     execute if score @s 9G.AnimationTimer matches 39..42 at @s positioned ^ ^0.2 ^ run function asset:mob/0340.twins_rubiel/app/general/3.teleport
     execute if score @s 9G.AnimationTimer matches 65..75 at @s positioned ^ ^0.05 ^-0.05 run function asset:mob/0340.twins_rubiel/app/general/3.teleport
     # ベクトル計算移動
-        execute if score @s 9G.AnimationTimer matches 34 positioned as @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] run summon area_effect_cloud ^ ^0.1 ^-1 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9G.Temp.Target.Aec.0"]}
+        execute if score @s 9G.AnimationTimer matches 34 positioned as @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] run summon area_effect_cloud ^ ^0.1 ^-1 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9G.Temp.Target.Aec.0"]}
         execute if score @s 9G.AnimationTimer matches 34 if entity @e[type=area_effect_cloud,tag=9G.Temp.Target.Aec.0] run function asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/03_2_kt_movetospear/4.calc_vector_0
-        execute if score @s 9G.AnimationTimer matches 45 positioned as @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] run summon area_effect_cloud ^ ^0.1 ^-2 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9G.Temp.Target.Aec.0"]}
+        execute if score @s 9G.AnimationTimer matches 45 positioned as @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] run summon area_effect_cloud ^ ^0.1 ^-2 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9G.Temp.Target.Aec.0"]}
         execute if score @s 9G.AnimationTimer matches 45 if entity @e[type=area_effect_cloud,tag=9G.Temp.Target.Aec.0] run function asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/03_2_kt_movetospear/4.calc_vector_1
         execute if score @s 9G.AnimationTimer matches 36..40 at @s run function asset:mob/0340.twins_rubiel/app/general/4.teleport_using_vector
         execute if score @s 9G.AnimationTimer matches 45..50 at @s run function asset:mob/0340.twins_rubiel/app/general/4.teleport_using_vector

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/05_1_kt_setwarp/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/05_1_kt_setwarp/1.main.mcfunction
@@ -16,9 +16,9 @@
     execute if score @s 9G.AnimationTimer matches 30 run playsound entity.phantom.flap hostile @a ~ ~ ~ 1 1.2
     execute if score @s 9G.AnimationTimer matches 30 run particle flash ~ ~1 ~ 0 0 0 0 1
 # ワープポイント設置
-    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] rotated ~ 0 run summon area_effect_cloud ^2 ^0.2 ^3 {CustomNameVisible:0b,Particle:"block air",Duration:82,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.0"]}
-    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] rotated ~ 0 run summon area_effect_cloud ^-8 ^6 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:82,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.1"]}
-    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] rotated ~ 0 run summon area_effect_cloud ^2 ^2 ^12 {CustomNameVisible:0b,Particle:"block air",Duration:82,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.2"]}
+    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] rotated ~ 0 run summon area_effect_cloud ^2 ^0.2 ^3 {CustomNameVisible:0b,Particle:"block air",Duration:82,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.0"]}
+    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] rotated ~ 0 run summon area_effect_cloud ^-8 ^6 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:82,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.1"]}
+    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] rotated ~ 0 run summon area_effect_cloud ^2 ^2 ^12 {CustomNameVisible:0b,Particle:"block air",Duration:82,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.2"]}
 # 移動
     execute if score @s 9G.AnimationTimer matches 35 positioned as @e[type=area_effect_cloud,tag=9G.Temp.Target.Warp.0] facing entity @p feet run tp @s ~ ~ ~ ~ 0
     execute if score @s 9G.AnimationTimer matches 35 run kill @e[type=area_effect_cloud,tag=9G.Temp.Target.Warp.0]

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_1_kt_jumpslash/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_1_kt_jumpslash/1.main.mcfunction
@@ -13,9 +13,9 @@
     execute if score @s 9G.AnimationTimer matches 14..18 at @s positioned ^ ^0.2 ^ run function asset:mob/0340.twins_rubiel/app/general/3.teleport
     execute if score @s 9G.AnimationTimer matches 19..23 at @s positioned ^ ^0.1 ^ run function asset:mob/0340.twins_rubiel/app/general/3.teleport
     # ベクトル計算移動
-        execute if score @s 9G.AnimationTimer matches 12 positioned as @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] run summon area_effect_cloud ^ ^4 ^-3 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9G.Temp.Target.Aec.0"]}
+        execute if score @s 9G.AnimationTimer matches 12 positioned as @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] run summon area_effect_cloud ^ ^4 ^-3 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9G.Temp.Target.Aec.0"]}
         execute if score @s 9G.AnimationTimer matches 13 if entity @e[type=area_effect_cloud,tag=9G.Temp.Target.Aec.0] run function asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/07_1_kt_jumpslash/4.calc_vector_0
-        execute if score @s 9G.AnimationTimer matches 28 positioned as @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] run summon area_effect_cloud ^ ^0.1 ^-2 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9G.Temp.Target.Aec.0"]}
+        execute if score @s 9G.AnimationTimer matches 28 positioned as @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] run summon area_effect_cloud ^ ^0.1 ^-2 {CustomNameVisible:0b,Particle:"block air",Duration:2,Tags:["Object","9G.Temp.Target.Aec.0"]}
         execute if score @s 9G.AnimationTimer matches 29 if entity @e[type=area_effect_cloud,tag=9G.Temp.Target.Aec.0] run function asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/07_1_kt_jumpslash/4.calc_vector_1
         execute if score @s 9G.AnimationTimer matches 13..26 at @s run function asset:mob/0340.twins_rubiel/app/general/4.teleport_using_vector
         execute if score @s 9G.AnimationTimer matches 33..37 at @s run function asset:mob/0340.twins_rubiel/app/general/4.teleport_using_vector
@@ -29,7 +29,7 @@
     execute if score @s 9G.AnimationTimer matches 35 run playsound ogg:item.trident.return1 hostile @a ~ ~ ~ 2 1.3
     execute if score @s 9G.AnimationTimer matches 37 run playsound entity.hoglin.step hostile @a ~ ~ ~ 2 0.7
     execute if score @s 9G.AnimationTimer matches 37 at @s run particle block quartz_block ~ ~0.1 ~ 0.5 0 0.5 0 30
- 
+
 # 斬撃演出
     execute if score @s 9G.AnimationTimer matches 33 at @s positioned ^ ^2.0 ^1 rotated ~0 -30 run function asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/07_1_kt_jumpslash/6.1.particle_slash
     execute if score @s 9G.AnimationTimer matches 34..37 at @s positioned ^ ^1.0 ^2 rotated ~0 -10 run function asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/07_1_kt_jumpslash/6.1.particle_slash

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/13_sc_warp/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/13_sc_warp/1.main.mcfunction
@@ -15,12 +15,12 @@
     execute if score @s 9G.AnimationTimer matches 30 run playsound entity.phantom.flap hostile @a ~ ~ ~ 1 1.2
     execute if score @s 9G.AnimationTimer matches 30 run particle flash ~ ~1 ~ 0 0 0 0 1
 # ワープポイント設置
-    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] rotated ~30 0 run summon area_effect_cloud ^ ^1.2 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:160,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.0"]}
-    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] rotated ~90 0 run summon area_effect_cloud ^ ^1.2 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:160,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.1"]}
-    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] rotated ~150 0 run summon area_effect_cloud ^ ^1.2 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:160,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.2"]}
-    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] rotated ~210 0 run summon area_effect_cloud ^ ^1.2 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:160,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.2"]}
-    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] rotated ~270 0 run summon area_effect_cloud ^ ^1.2 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:160,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.1"]}
-    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] rotated ~330 0 run summon area_effect_cloud ^ ^1.2 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:160,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.0"]}
+    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] rotated ~30 0 run summon area_effect_cloud ^ ^1.2 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:160,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.0"]}
+    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] rotated ~90 0 run summon area_effect_cloud ^ ^1.2 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:160,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.1"]}
+    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] rotated ~150 0 run summon area_effect_cloud ^ ^1.2 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:160,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.2"]}
+    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] rotated ~210 0 run summon area_effect_cloud ^ ^1.2 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:160,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.2"]}
+    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] rotated ~270 0 run summon area_effect_cloud ^ ^1.2 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:160,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.1"]}
+    execute if score @s 9G.AnimationTimer matches 13 at @a[tag=!PlayerShouldInvulnerable,distance=..50,sort=nearest,limit=1] rotated ~330 0 run summon area_effect_cloud ^ ^1.2 ^8 {CustomNameVisible:0b,Particle:"block air",Duration:160,Tags:["Object","9G.Temp.Target.Warp","9G.Temp.Target.Warp.0"]}
 
 ## 攻撃
 # 移動

--- a/Asset/data/asset/functions/object/2200.twins_escape_animation/tick/event_rubiel.mcfunction
+++ b/Asset/data/asset/functions/object/2200.twins_escape_animation/tick/event_rubiel.mcfunction
@@ -10,6 +10,9 @@
 # アニメーション再生
     execute if score @s General.Object.Tick matches 1 run function animated_java:twins_rubiel/animations/42_escape/tween {duration:1, to_frame: 1}
 
+# 移動
+    execute if block ~ ~-0.5 ~ #lib:no_collision run tp @s ~ ~-0.5 ~
+
 # 演出
     execute if score @s General.Object.Tick matches 59 run playsound entity.phantom.flap hostile @a ~ ~ ~ 3 1.2
     execute if score @s General.Object.Tick matches 66 run playsound item.trident.return hostile @a ~ ~ ~ 1 0.7

--- a/Asset/data/asset/functions/object/2200.twins_escape_animation/tick/event_rubiel.mcfunction
+++ b/Asset/data/asset/functions/object/2200.twins_escape_animation/tick/event_rubiel.mcfunction
@@ -11,7 +11,7 @@
     execute if score @s General.Object.Tick matches 1 run function animated_java:twins_rubiel/animations/42_escape/tween {duration:1, to_frame: 1}
 
 # 移動
-    execute if block ~ ~-0.5 ~ #lib:no_collision run tp @s ~ ~-0.5 ~
+    execute if block ~ ~-0.1 ~ #lib:no_collision run tp @s ~ ~-0.1 ~
 
 # 演出
     execute if score @s General.Object.Tick matches 59 run playsound entity.phantom.flap hostile @a ~ ~ ~ 3 1.2

--- a/Asset/data/asset/functions/object/2200.twins_escape_animation/tick/event_sapphiel.mcfunction
+++ b/Asset/data/asset/functions/object/2200.twins_escape_animation/tick/event_sapphiel.mcfunction
@@ -11,7 +11,7 @@
     execute if score @s General.Object.Tick matches 1 run function animated_java:twins_sapphiel/animations/42_escape/tween {duration:1, to_frame: 1}
 
 # 移動
-    execute if block ~ ~-0.5 ~ #lib:no_collision run tp @s ~ ~-0.5 ~
+    execute if block ~ ~-0.1 ~ #lib:no_collision run tp @s ~ ~-0.1 ~
 
 # 演出
     execute if score @s General.Object.Tick matches 59 run playsound entity.phantom.flap hostile @a ~ ~ ~ 3 1.2

--- a/Asset/data/asset/functions/object/2200.twins_escape_animation/tick/event_sapphiel.mcfunction
+++ b/Asset/data/asset/functions/object/2200.twins_escape_animation/tick/event_sapphiel.mcfunction
@@ -10,6 +10,9 @@
 # アニメーション再生
     execute if score @s General.Object.Tick matches 1 run function animated_java:twins_sapphiel/animations/42_escape/tween {duration:1, to_frame: 1}
 
+# 移動
+    execute if block ~ ~-0.5 ~ #lib:no_collision run tp @s ~ ~-0.5 ~
+
 # 演出
     execute if score @s General.Object.Tick matches 59 run playsound entity.phantom.flap hostile @a ~ ~ ~ 3 1.2
     execute if score @s General.Object.Tick matches 66 run playsound item.trident.return hostile @a ~ ~ ~ 1 0.7


### PR DESCRIPTION
- ルビエル、サフィエル単体のbossbarの消去処理をinitに追記
- 撤退アニメーション時、床の位置までゆっくり下がるようにした。床が無い場所で倒しても最大で6ブロックしか下がらないはずなので、奈落には落ちないと思う
- ワープ、ベクトル移動を含むターゲットの決定処理にdistanceを追加。遥か遠くまで追いかけることは無くなったと思う