### PR TITLE
🚸 [Mob372] ツタンカーメンの調整

### DIFF
--- a/Asset/data/asset/functions/mob/0372.tutankhamen/load.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/load.mcfunction
@@ -9,3 +9,4 @@
     scoreboard objectives add AC.TargetID dummy
     scoreboard objectives add AC.Count.Dash dummy
     scoreboard objectives add AC.Count.Attack dummy
+    scoreboard objectives add AC.Count.Stuck dummy

--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/.mcfunction
@@ -35,8 +35,14 @@
 # 足元に何もなければ
     execute if block ~ ~-0.2 ~ #lib:no_collision run particle minecraft:enchant ~ ~ ~ 0.4 0 0.4 0 10
 
-# 足元が埋まっている間は上にちょっとずつ登る
-    execute unless block ~ ~ ~ #lib:no_collision run tp @s ~ ~0.1 ~
+# スタックに対するカウンター、ブロック破壊が可能なエリアでのみ行う
+    execute if predicate api:area/is_breakable run function asset:mob/0372.tutankhamen/tick/stuck_revenge/
+
+# 足元が埋まっていて、上にブロックがないなら上に移動
+    execute unless block ~ ~ ~ #lib:no_collision if block ~ ~2.5 ~ #lib:no_collision run tp @s ~ ~0.1 ~
+
+# 頭上にブロックがあって、下にブロックがないなら下に移動
+    execute unless block ~ ~2.5 ~ #lib:no_collision if block ~ ~-1 ~ #lib:no_collision run tp @s ~ ~-0.1 ~
 
 # そこらのプレイヤーより下にいる場合、上昇する
     execute positioned ~-50 ~ ~-50 unless entity @a[dx=99,dy=-50,dz=99] at @s[tag=!AC.Opening,tag=!AC.InAction] run tp @s ~ ~0.1 ~

--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/dash_select.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/dash_select.mcfunction
@@ -21,7 +21,7 @@
     execute store result score $Random Temporary run function lib:random/with_biased/manual.m with storage lib: Args
 
 # デバッグのコマンド
-#    scoreboard players set $Random Temporary 3
+    scoreboard players set $Random Temporary 3
 
 # スキル選択
     execute if score $Random Temporary matches 0..1 run tag @s add AC.Dash.Side

--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/dash_select.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/dash_select.mcfunction
@@ -21,7 +21,7 @@
     execute store result score $Random Temporary run function lib:random/with_biased/manual.m with storage lib: Args
 
 # デバッグのコマンド
-    scoreboard players set $Random Temporary 3
+#    scoreboard players set $Random Temporary 3
 
 # スキル選択
     execute if score $Random Temporary matches 0..1 run tag @s add AC.Dash.Side

--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/charge/.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/charge/.mcfunction
@@ -8,9 +8,9 @@
     execute if score @s General.Mob.Tick matches 0 run function asset:mob/0372.tutankhamen/tick/skill/dash/charge/backstep
 
 # 後ろに下がる
-    execute if score @s General.Mob.Tick matches 0..5 rotated ~ 0 run tp @s ^ ^ ^-0.5
-    execute if score @s General.Mob.Tick matches 6..10 rotated ~ 0 run tp @s ^ ^ ^-0.3
-    execute if score @s General.Mob.Tick matches 11..15 rotated ~ 0 run tp @s ^ ^ ^-0.1
+    execute if score @s General.Mob.Tick matches 0..5 rotated ~ 0 unless function asset:mob/0372.tutankhamen/tick/skill/dash/charge/check_collide_back run tp @s ^ ^ ^-0.5
+    execute if score @s General.Mob.Tick matches 6..10 rotated ~ 0 unless function asset:mob/0372.tutankhamen/tick/skill/dash/charge/check_collide_back run tp @s ^ ^ ^-0.3
+    execute if score @s General.Mob.Tick matches 11..15 rotated ~ 0 unless function asset:mob/0372.tutankhamen/tick/skill/dash/charge/check_collide_back run tp @s ^ ^ ^-0.1
 
 # 突進開始アニメ
     execute if score @s General.Mob.Tick matches 15 run function asset:mob/0372.tutankhamen/tick/skill/dash/charge/start

--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/charge/check_collide.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/charge/check_collide.mcfunction
@@ -1,0 +1,8 @@
+#> asset:mob/0372.tutankhamen/tick/skill/dash/charge/check_collide
+#
+#
+#
+# @within function asset:mob/0372.tutankhamen/tick/skill/dash/charge/move
+
+execute unless block ^ ^ ^1.5 #lib:no_collision run return 1
+execute anchored eyes unless block ^ ^ ^1.5 #lib:no_collision run return 1

--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/charge/check_collide_back.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/charge/check_collide_back.mcfunction
@@ -1,0 +1,8 @@
+#> asset:mob/0372.tutankhamen/tick/skill/dash/charge/check_collide_back
+#
+# 背後にブロックがないかチェック
+#
+# @within function asset:mob/0372.tutankhamen/tick/skill/dash/charge/
+
+execute unless block ^ ^ ^-0.5 #lib:no_collision run return 1
+execute anchored eyes unless block ^ ^ ^-0.5 #lib:no_collision run return 1

--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/charge/move.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/charge/move.mcfunction
@@ -8,9 +8,8 @@
 # @private
     #declare score_holder $Interval
 
-# 壁チェック
-    execute at @s if function asset:mob/0372.tutankhamen/tick/skill/dash/check_collide run tp @s ~ ~0.5 ~ ~ 0
-    execute at @s if function asset:mob/0372.tutankhamen/tick/skill/dash/check_collide run scoreboard players set @s General.Mob.Tick 30
+# 壁があったら止まる
+    execute at @s if function asset:mob/0372.tutankhamen/tick/skill/dash/charge/check_collide run scoreboard players set @s General.Mob.Tick 30
 
 # 弱ホーミングダッシュ
     execute facing entity @p[gamemode=!spectator] feet positioned ^ ^ ^-10 rotated as @s positioned ^ ^ ^-80 facing entity @s feet positioned as @s rotated ~ ~ run tp @s ^ ^ ^1.5 ~ ~

--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/charge/move.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/charge/move.mcfunction
@@ -9,6 +9,7 @@
     #declare score_holder $Interval
 
 # 壁があったら止まる
+    execute at @s if function asset:mob/0372.tutankhamen/tick/skill/dash/charge/check_collide run tp @s ~ ~ ~ ~ 0
     execute at @s if function asset:mob/0372.tutankhamen/tick/skill/dash/charge/check_collide run scoreboard players set @s General.Mob.Tick 30
 
 # 弱ホーミングダッシュ

--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/dash_slash/move.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/dash_slash/move.mcfunction
@@ -8,8 +8,7 @@
 # @private
     #declare score_holder $Interval
 
-# 壁チェック
-    execute at @s if function asset:mob/0372.tutankhamen/tick/skill/dash/check_collide run tp @s ~ ~ ~ ~ 0
+# 壁があったら移動をやめる
     execute at @s if function asset:mob/0372.tutankhamen/tick/skill/dash/check_collide run scoreboard players set @s General.Mob.Tick 100
 
 # ホーミング

--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/dash_slash/move.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/dash_slash/move.mcfunction
@@ -9,6 +9,7 @@
     #declare score_holder $Interval
 
 # 壁があったら移動をやめる
+    execute at @s if function asset:mob/0372.tutankhamen/tick/skill/dash/check_collide run tp @s ~ ~ ~ ~ 0
     execute at @s if function asset:mob/0372.tutankhamen/tick/skill/dash/check_collide run scoreboard players set @s General.Mob.Tick 100
 
 # ホーミング

--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/side/move.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/side/move.mcfunction
@@ -5,6 +5,7 @@
 # @within function asset:mob/0372.tutankhamen/tick/skill/dash/side/
 
 # 壁があったら移動をやめる
+    execute at @s if function asset:mob/0372.tutankhamen/tick/skill/dash/check_collide run tp @s ~ ~ ~ ~ 0
     execute at @s if function asset:mob/0372.tutankhamen/tick/skill/dash/check_collide run scoreboard players set @s General.Mob.Tick 30
 
 # 横に移動

--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/side/move.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/dash/side/move.mcfunction
@@ -4,8 +4,7 @@
 #
 # @within function asset:mob/0372.tutankhamen/tick/skill/dash/side/
 
-# 壁チェック
-    execute at @s if function asset:mob/0372.tutankhamen/tick/skill/dash/check_collide run tp @s ~ ~ ~ ~ 0
+# 壁があったら移動をやめる
     execute at @s if function asset:mob/0372.tutankhamen/tick/skill/dash/check_collide run scoreboard players set @s General.Mob.Tick 30
 
 # 横に移動

--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/stuck_revenge/.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/stuck_revenge/.mcfunction
@@ -1,0 +1,19 @@
+#> asset:mob/0372.tutankhamen/tick/stuck_revenge/
+#
+# ブロックでスタックしてしまったとき、周囲のブロックを壊して復帰する
+#
+# @within function asset:mob/0372.tutankhamen/tick/
+
+# 頭がめり込んでいる場合、カウント付与。
+    execute unless block ~ ~2.5 ~ #lib:no_collision run scoreboard players add @s AC.Count.Stuck 1
+
+# 頭がめり込んでなければカウントが減少
+    execute if block ~ ~2.5 ~ #lib:no_collision unless score @s AC.Count.Stuck matches ..-1 run scoreboard players remove @s AC.Count.Stuck 1
+
+# カウント一定以上でガタガタ音がなる
+    scoreboard players operation $Interval Temporary = @s General.Mob.Tick
+    scoreboard players operation $Interval Temporary %= $5 Const
+    execute if score $Interval Temporary matches 0 if score @s AC.Count.Stuck matches 20.. run function asset:mob/0372.tutankhamen/tick/stuck_revenge/anger
+
+# カウントが更に貯まると反撃してくる
+    execute if score @s AC.Count.Stuck matches 40.. run function asset:mob/0372.tutankhamen/tick/stuck_revenge/explosion

--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/stuck_revenge/anger.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/stuck_revenge/anger.mcfunction
@@ -1,0 +1,8 @@
+#> asset:mob/0372.tutankhamen/tick/stuck_revenge/anger
+#
+# ハマりの演出
+#
+# @within function asset:mob/0372.tutankhamen/tick/stuck_revenge/
+
+particle minecraft:angry_villager ~ ~2.5 ~ 0.2 0 0.2 0 1
+playsound entity.wither_skeleton.hurt hostile @a ~ ~ ~ 1 1.5

--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/stuck_revenge/break.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/stuck_revenge/break.mcfunction
@@ -1,0 +1,42 @@
+#> asset:mob/0372.tutankhamen/tick/stuck_revenge/break
+#
+#
+#
+# @within function asset:mob/0372.tutankhamen/tick/stuck_revenge/explosion
+
+
+    execute positioned ~ ~ ~ unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~ ~1 ~ unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~ ~2 ~ unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+
+    execute positioned ~1 ~ ~ unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~1 ~1 ~ unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~1 ~2 ~ unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+
+    execute positioned ~-1 ~ ~ unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~-1 ~1 ~ unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~-1 ~2 ~ unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+
+    execute positioned ~ ~ ~1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~ ~1 ~1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~ ~2 ~1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+
+    execute positioned ~1 ~ ~1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~1 ~1 ~1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~1 ~2 ~1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+
+    execute positioned ~-1 ~ ~1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~-1 ~1 ~1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~-1 ~2 ~1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+
+    execute positioned ~ ~ ~-1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~ ~1 ~-1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~ ~2 ~-1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+
+    execute positioned ~1 ~ ~-1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~1 ~1 ~-1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~1 ~2 ~-1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+
+    execute positioned ~-1 ~ ~-1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~-1 ~1 ~-1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy
+    execute positioned ~-1 ~2 ~-1 unless block ~ ~ ~ #lib:unbreakable run setblock ~ ~ ~ air destroy

--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/stuck_revenge/explosion.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/stuck_revenge/explosion.mcfunction
@@ -1,0 +1,14 @@
+#> asset:mob/0372.tutankhamen/tick/stuck_revenge/explosion
+#
+# 爆発！
+#
+# @within function asset:mob/0372.tutankhamen/tick/stuck_revenge/
+
+# 演出
+    playsound minecraft:entity.wither.hurt hostile @a ~ ~ ~ 1 1.5
+
+# 壁破壊
+    execute positioned ~ ~0.1 ~ run function asset:mob/0372.tutankhamen/tick/stuck_revenge/break
+
+# リセット
+    scoreboard players reset @s AC.Count.Stuck


### PR DESCRIPTION
- 埋まると上に登っていってしまうのを修正。埋まり防止処理は、それぞれ上下に空きがあるときのみ行うようになりました。(Fix #624 )
- 実はスポーン地点を囲われたりすると移動ができなくなっていたので、ブロックから抜け出す処理を追加。ついでに万が一埋まったときにも役立つでしょう(Fix #557 )
- 各移動処理をちょっと見直してちょっとだけ埋まりづらくなった…はず。それでもTPなので、埋まるときは埋まると思います。