### PR TITLE
🐛 [神器1059] 召喚したオブジェクトが即座に消滅する問題を修正

### DIFF
--- a/Asset/data/asset/functions/object/1059.book_of_hero/tick/.mcfunction
+++ b/Asset/data/asset/functions/object/1059.book_of_hero/tick/.mcfunction
@@ -40,12 +40,12 @@
     execute unless block ^ ^ ^0.5 #lib:no_collision at @s run tp @s ~ ~ ~ ~45 ~-45
     execute at @s unless block ^ ^ ^0.2 #lib:no_collision at @s run tp @s ~ ~ ~ ~45 ~-45
 
+# 離れ過ぎたら消える
+    execute unless entity @a[tag=1059.OwnerPlayer,distance=..70] run kill @s
+
 # リセット
     scoreboard players reset $OwnerID Temporary
     tag @a[tag=1059.OwnerPlayer,distance=..80] remove 1059.OwnerPlayer
-
-# 離れ過ぎたら消える
-    execute unless entity @a[tag=1059.OwnerPlayer,distance=..70] run kill @s
 
 # 消滅処理
     kill @s[scores={General.Object.Tick=300..}]

--- a/Asset/data/asset/functions/object/1059.book_of_hero/tick/.mcfunction
+++ b/Asset/data/asset/functions/object/1059.book_of_hero/tick/.mcfunction
@@ -41,11 +41,11 @@
     execute at @s unless block ^ ^ ^0.2 #lib:no_collision at @s run tp @s ~ ~ ~ ~45 ~-45
 
 # 離れ過ぎたら消える
-    execute unless entity @a[tag=1059.OwnerPlayer,distance=..70] run kill @s
+    execute unless entity @a[tag=1059.OwnerPlayer,distance=..70] run function asset:object/1059.book_of_hero/tick/kill
 
 # リセット
     scoreboard players reset $OwnerID Temporary
     tag @a[tag=1059.OwnerPlayer,distance=..80] remove 1059.OwnerPlayer
 
 # 消滅処理
-    kill @s[scores={General.Object.Tick=300..}]
+    execute if entity @s[scores={General.Object.Tick=300..}] run function asset:object/1059.book_of_hero/tick/kill

--- a/Asset/data/asset/functions/object/1059.book_of_hero/tick/attack.mcfunction
+++ b/Asset/data/asset/functions/object/1059.book_of_hero/tick/attack.mcfunction
@@ -33,7 +33,7 @@
     # tellraw @a [{"text":"Progress: "},{"score":{"name":"$Progress","objective":"Temporary"}},{"text":" Level: "},{"score":{"name":"$Level","objective":"Temporary"}},{"text":" Damage: "},{"score":{"name":"$Damage","objective":"Temporary"}}]
 
 # 属性
-    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.AttackType set value "Magic"
     data modify storage api: Argument.ElementType set value "None"
 # ダメージ
     execute store result score $OwnerID Temporary run data get storage asset:context this.UserID

--- a/Asset/data/asset/functions/object/1059.book_of_hero/tick/kill.mcfunction
+++ b/Asset/data/asset/functions/object/1059.book_of_hero/tick/kill.mcfunction
@@ -1,0 +1,12 @@
+#> asset:object/1059.book_of_hero/tick/kill
+#
+# 消滅処理
+#
+# @within function asset:object/1059.book_of_hero/tick/
+
+# 演出
+    particle end_rod ~ ~ ~ 0 0 0 0.2 30
+    playsound entity.zombie.break_wooden_door neutral @a ~ ~ ~ 0.2 0.7 0
+
+# 消える
+    kill @s


### PR DESCRIPTION
Fix #677 
・召喚できない問題を修正
・実際の攻撃属性が表記と異なるのを修正
・消滅演出を追加