### PR TITLE
🐛 [Mob 377] 灰の守護者がremoveで消えない問題を修正

### DIFF
--- a/Asset/data/asset/functions/mob/0377.grey_guardian_v2/remove/.mcfunction
+++ b/Asset/data/asset/functions/mob/0377.grey_guardian_v2/remove/.mcfunction
@@ -7,4 +7,4 @@
 function asset:mob/super.remove
 
 
-execute as @e[type=item_display,distance=..0.1,sort=nearest,limit=1] run function animated_java:grey_guardian/remove/this
+execute as @e[type=item_display,tag=AH.AJ,distance=..100,sort=nearest,limit=1] run function animated_java:grey_guardian/remove/this


### PR DESCRIPTION
fix #740