### PR TITLE
[Object2113] 四角形予告の改善

### DIFF
--- a/Asset/data/asset/functions/object/2113.rectangle_announce/init/.mcfunction
+++ b/Asset/data/asset/functions/object/2113.rectangle_announce/init/.mcfunction
@@ -7,5 +7,5 @@
 # KillするTickを指定
     execute store result score @s 2113.Tick run data get storage asset:context this.Tick
 
-# this.Scale[1]の半分をthis.translationZへ
-    execute store result storage asset:context this.TranslationZ float 0.05 run data get storage asset:context this.Scale[1] 10
+# ToForward:trueなら、this.Scale[1]の半分をthis.translationZへ
+    execute if data storage asset:context this{ToForward:true} store result storage asset:context this.TranslationZ float 0.05 run data get storage asset:context this.Scale[1] 10

--- a/Asset/data/asset/functions/object/2113.rectangle_announce/register.mcfunction
+++ b/Asset/data/asset/functions/object/2113.rectangle_announce/register.mcfunction
@@ -17,6 +17,7 @@
 # ID (int)
     data modify storage asset:object ID set value 2113
 # フィールド(オプション)
+    data modify storage asset:object Field.ToForward set value true
     data modify storage asset:object Field.RotationX set value 0.0f
     data modify storage asset:object Field.Color set value 10000
     data modify storage asset:object Field.Interpolation set value 0

--- a/Asset/data/asset/functions/object/2113.rectangle_announce/register.mcfunction
+++ b/Asset/data/asset/functions/object/2113.rectangle_announce/register.mcfunction
@@ -19,7 +19,7 @@
 # フィールド(オプション)
     data modify storage asset:object Field.ToForward set value true
     data modify storage asset:object Field.RotationX set value 0.0f
-    data modify storage asset:object Field.Color set value 10000
-    data modify storage asset:object Field.Interpolation set value 0
-    data modify storage asset:object Field.Scale set value [5f,10f]
-    data modify storage asset:object Field.Tick set value 50
+    data modify storage asset:object Field.Color set value 16745239
+    data modify storage asset:object Field.Interpolation set value 10
+    data modify storage asset:object Field.Scale set value [2.5f,10f]
+    data modify storage asset:object Field.Tick set value 20

--- a/Asset/data/asset/functions/object/2113.rectangle_announce/summon/debug.mcfunction
+++ b/Asset/data/asset/functions/object/2113.rectangle_announce/summon/debug.mcfunction
@@ -8,6 +8,9 @@
 # 見てる方向へRotationXを設定
     data modify storage api: Argument.FieldOverride.RotationX set from entity @s Rotation[0]
 
+# 前方へ進まない設定
+    # data modify storage api: Argument.FieldOverride.ToForward set value false
+
 # 召喚
     data modify storage api: Argument.ID set value 2113
     function api:object/summon

--- a/Asset/data/asset/functions/object/2113.rectangle_announce/tick/transform.mcfunction
+++ b/Asset/data/asset/functions/object/2113.rectangle_announce/tick/transform.mcfunction
@@ -11,7 +11,7 @@
     data modify entity @s interpolation_duration set from storage asset:context this.Interpolation
 
 # translationZ
-    data modify entity @s transformation.translation[2] set from storage asset:context this.TranslationZ
+    execute if data storage asset:context this{ToForward:true} run data modify entity @s transformation.translation[2] set from storage asset:context this.TranslationZ
 
 # 指定されたScaleZに変化
 # 確かに奥行きではあるのだが、内部的にはyなのである、どうしようね


### PR DESCRIPTION
・Field.ToForwardを追加 (default : true)
trueなら今まで通り前に伸びる
falseにすると両方に伸びるようになる
