### PR TITLE
[神器0905] 転移の書をtpbanでは使用不可に

### DIFF
--- a/Asset/data/asset/functions/artifact/0905.book_of_metastasis/trigger/2.check_condition.mcfunction
+++ b/Asset/data/asset/functions/artifact/0905.book_of_metastasis/trigger/2.check_condition.mcfunction
@@ -8,6 +8,13 @@
     function asset:artifact/common/check_condition/auto
 # 他にアイテム等確認する場合はここに書く
 
+# tpbanでは使用不可
+    execute if predicate lib:is_ban_tp_area run function lib:message/artifact/can_not_use_here
+    execute if predicate lib:is_ban_tp_area run tag @s remove CanUsed
+
+# 念のためtpbanならreturnしておく
+    execute if predicate lib:is_ban_tp_area run return 0
+
 # 既に発動している場合、テレポートはここで発動してしまう(MP消費したくないし)
     execute if entity @s[tag=CanUsed] as @e[type=area_effect_cloud,tag=P5.Bullet,distance=..150] if score @s P5.UserID = @p[tag=this] UserID run tag @s remove CanUsed
     execute as @e[type=area_effect_cloud,tag=P5.Bullet,distance=..150] if score @s P5.UserID = @p[tag=this] UserID at @s run function asset:artifact/0905.book_of_metastasis/trigger/teleport


### PR DESCRIPTION
Fix #812