### PR TITLE
[Mob1004] ラスボスの問題のさらなる修正

### DIFF
--- a/Asset/data/asset/functions/mob/1004.tultaria/tick/base_move/reset.mcfunction
+++ b/Asset/data/asset/functions/mob/1004.tultaria/tick/base_move/reset.mcfunction
@@ -53,4 +53,4 @@
     scoreboard players set @s RW.Speed 5
 
 # ランダム移動
-    execute at @r[distance=..64] run function asset:mob/1004.tultaria/tick/move/teleport/place_marker.m with storage asset:context this.Pos
+    execute at @r[gamemode=!spectator,distance=..64] run function asset:mob/1004.tultaria/tick/move/teleport/place_marker.m with storage asset:context this.Pos

--- a/Asset/data/asset/functions/mob/1004.tultaria/tick/base_move/teleport/.mcfunction
+++ b/Asset/data/asset/functions/mob/1004.tultaria/tick/base_move/teleport/.mcfunction
@@ -8,7 +8,7 @@
     execute at @s positioned ~ ~1 ~ run function asset:mob/1004.tultaria/tick/base_move/teleport/vfx
 
 # 拡散
-    execute at @r[distance=..60] positioned ~ ~1 ~ run function lib:spread_entity/
+    execute at @r[gamemode=!spectator,distance=..64] positioned ~ ~1 ~ run function lib:spread_entity/
 
 # プレイヤーが近すぎたらバック
     execute at @s if entity @p[gamemode=!spectator,distance=..128] rotated ~ 0 run tp @s ^ ^ ^-10

--- a/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/fire/meteor_rain/meteor/summon.mcfunction
+++ b/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/fire/meteor_rain/meteor/summon.mcfunction
@@ -14,7 +14,7 @@
 
 # 拡散
     data modify storage lib: Argument.Bounds set value [[16d,16d],[0d,0d],[16d,16d]]
-    execute as @e[type=marker,tag=SpreadMarker,limit=1] at @r[distance=..100] run function lib:spread_entity/
+    execute as @e[type=marker,tag=SpreadMarker,limit=1] at @r[gamemode=!spectator,distance=..64] run function lib:spread_entity/
 
 # 召喚IDを指定
     data modify storage api: Argument.ID set value 2028

--- a/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/fire/meteor_rain/pattern/1.mcfunction
+++ b/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/fire/meteor_rain/pattern/1.mcfunction
@@ -13,7 +13,7 @@
         execute if score @s General.Mob.Tick matches 20 run function asset:mob/1004.tultaria/tick/skill/fire/meteor_rain/meteor/spread
         execute if score @s General.Mob.Tick matches 20 run function asset:mob/1004.tultaria/tick/skill/fire/meteor_rain/meteor/spread
     # プレイヤー狙い
-        execute if score @s General.Mob.Tick matches 20 at @r[distance=..100] run function asset:mob/1004.tultaria/tick/skill/fire/meteor_rain/meteor/aim
+        execute if score @s General.Mob.Tick matches 20 at @r[gamemode=!spectator,distance=..64] run function asset:mob/1004.tultaria/tick/skill/fire/meteor_rain/meteor/aim
 
 # メテオ落下2
     # サウンド
@@ -24,7 +24,7 @@
         execute if score @s General.Mob.Tick matches 40 run function asset:mob/1004.tultaria/tick/skill/fire/meteor_rain/meteor/spread
         execute if score @s General.Mob.Tick matches 40 run function asset:mob/1004.tultaria/tick/skill/fire/meteor_rain/meteor/spread
     # プレイヤー狙い
-        execute if score @s General.Mob.Tick matches 20 at @r[distance=..100] run function asset:mob/1004.tultaria/tick/skill/fire/meteor_rain/meteor/aim
+        execute if score @s General.Mob.Tick matches 20 at @r[gamemode=!spectator,distance=..64] run function asset:mob/1004.tultaria/tick/skill/fire/meteor_rain/meteor/aim
 
 # デバッグ用、この行動をループする
 #    execute if score @s General.Mob.Tick matches 100 run scoreboard players set @s General.Mob.Tick -10

--- a/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/fire/move_shot/first_move.m.mcfunction
+++ b/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/fire/move_shot/first_move.m.mcfunction
@@ -17,7 +17,7 @@
     kill @e[type=marker,tag=RW.TeleportMarker,distance=..128,sort=nearest,limit=1]
 
 # プレイヤーの足元に召喚
-    execute at @r run summon marker ~ ~ ~ {Tags:["RW.RotateMarker"]}
+    execute at @r[gamemode=!spectator,distance=..64] run summon marker ~ ~ ~ {Tags:["RW.RotateMarker"]}
 
 # プレイヤーから12ブロック離れた、ランダムな角度の位置にマーカーを置く
     $execute as @e[type=marker,tag=RW.RotateMarker,distance=..128,limit=1] at @s rotated $(Rotation) 0 run tp @s ^ ^ ^12

--- a/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/light/stellar_fury_1/fall_start.mcfunction
+++ b/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/light/stellar_fury_1/fall_start.mcfunction
@@ -9,7 +9,7 @@
     #declare tag 2030.Start
 
 # プレイヤーの向きを向かせる
-    tp @s ~ ~ ~ facing entity @r[distance=..100]
+    tp @s ~ ~ ~ facing entity @r[gamemode=!spectator,distance=..64]
 # タグを消す
     tag @s add 2030.Start
 # 演出

--- a/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/thunder/aiming_laser/move.m.mcfunction
+++ b/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/thunder/aiming_laser/move.m.mcfunction
@@ -17,7 +17,7 @@
     kill @e[type=marker,tag=RW.TeleportMarker,sort=nearest,limit=1]
 
 # プレイヤーの足元に召喚
-    execute at @r run summon marker ~ ~ ~ {Tags:["RW.RotateMarker"]}
+    execute at @r[distance=..64] run summon marker ~ ~ ~ {Tags:["RW.RotateMarker"]}
 
 # マーカーが回る
     $execute as @e[type=marker,tag=RW.RotateMarker,limit=1] at @s rotated $(Rotation) 0 run tp @s ^ ^ ^12

--- a/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/thunder/aiming_laser/move.m.mcfunction
+++ b/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/thunder/aiming_laser/move.m.mcfunction
@@ -17,7 +17,7 @@
     kill @e[type=marker,tag=RW.TeleportMarker,sort=nearest,limit=1]
 
 # プレイヤーの足元に召喚
-    execute at @r[distance=..64] run summon marker ~ ~ ~ {Tags:["RW.RotateMarker"]}
+    execute at @r[gamemode=!spectator,distance=..64] run summon marker ~ ~ ~ {Tags:["RW.RotateMarker"]}
 
 # マーカーが回る
     $execute as @e[type=marker,tag=RW.RotateMarker,limit=1] at @s rotated $(Rotation) 0 run tp @s ^ ^ ^12

--- a/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/thunder/lightning_stab/targeting.mcfunction
+++ b/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/thunder/lightning_stab/targeting.mcfunction
@@ -21,7 +21,7 @@
     playsound minecraft:item.trident.return hostile @a ~ ~ ~ 2 1.5
 
 # 周囲のランダムなプレイヤーを対象に
-    tag @r[distance=..80,limit=1] add TargetPlayer
+    tag @r[gamemode=!spectator,distance=..80,limit=1] add TargetPlayer
 
 # プレイヤーの周囲に大雑把にマーカー設置
     # 残ってたらヤなのでマーカーを消す

--- a/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/thunder/random_thunder/thunder/spread.mcfunction
+++ b/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/thunder/random_thunder/thunder/spread.mcfunction
@@ -8,7 +8,7 @@
 
 # 拡散
     data modify storage lib: Argument.Bounds set value [[10d,10d],[0d,0d],[10d,10d]]
-    execute at @r[distance=..100] run function lib:spread_entity/
+    execute at @r[gamemode=!spectator,distance=..64] run function lib:spread_entity/
 
 # 付近に雷落とすオブジェクトがいなければ、マーカーの位置にオブジェクト召喚
     execute at @s unless entity @e[type=item_display,scores={ObjectID=2041},distance=0.1..4,limit=1] run function asset:mob/1004.tultaria/tick/skill/thunder/random_thunder/thunder/summon

--- a/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/transition/phase_2_to_3/tick/attack/.mcfunction
+++ b/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/transition/phase_2_to_3/tick/attack/.mcfunction
@@ -64,16 +64,16 @@
         execute if score @s General.Mob.Tick matches 330 at @e[type=item_display,tag=!2026.Disabled,scores={ObjectID=2026,2026.ID=41},limit=1] run function asset:mob/1004.tultaria/tick/skill/platform_attack/purple
 
 # 3 誘導する光の柱を置く
-    execute if score @s General.Mob.Tick matches 370 at @r rotated 0 0 run function asset:mob/1004.tultaria/tick/skill/transition/phase_2_to_3/tick/attack/pillar/alert
+    execute if score @s General.Mob.Tick matches 370 at @r[gamemode=!spectator,distance=..64] rotated 0 0 run function asset:mob/1004.tultaria/tick/skill/transition/phase_2_to_3/tick/attack/pillar/alert
     execute if score @s General.Mob.Tick matches 390 at @e[type=marker,tag=RW.Marker.Aim,sort=nearest,limit=1] run function asset:mob/1004.tultaria/tick/skill/transition/phase_2_to_3/tick/attack/pillar/summon
 
-    execute if score @s General.Mob.Tick matches 430 at @r rotated 0 0 run function asset:mob/1004.tultaria/tick/skill/transition/phase_2_to_3/tick/attack/pillar/alert
+    execute if score @s General.Mob.Tick matches 430 at @r[gamemode=!spectator,distance=..64] rotated 0 0 run function asset:mob/1004.tultaria/tick/skill/transition/phase_2_to_3/tick/attack/pillar/alert
     execute if score @s General.Mob.Tick matches 450 at @e[type=marker,tag=RW.Marker.Aim,sort=nearest,limit=1] run function asset:mob/1004.tultaria/tick/skill/transition/phase_2_to_3/tick/attack/pillar/summon
 
-    execute if score @s General.Mob.Tick matches 490 at @r rotated 0 0 run function asset:mob/1004.tultaria/tick/skill/transition/phase_2_to_3/tick/attack/pillar/alert
+    execute if score @s General.Mob.Tick matches 490 at @r[gamemode=!spectator,distance=..64] rotated 0 0 run function asset:mob/1004.tultaria/tick/skill/transition/phase_2_to_3/tick/attack/pillar/alert
     execute if score @s General.Mob.Tick matches 510 at @e[type=marker,tag=RW.Marker.Aim,sort=nearest,limit=1] run function asset:mob/1004.tultaria/tick/skill/transition/phase_2_to_3/tick/attack/pillar/summon
 
-    execute if score @s General.Mob.Tick matches 550 at @r rotated 0 0 run function asset:mob/1004.tultaria/tick/skill/transition/phase_2_to_3/tick/attack/pillar/alert
+    execute if score @s General.Mob.Tick matches 550 at @r[gamemode=!spectator,distance=..64] rotated 0 0 run function asset:mob/1004.tultaria/tick/skill/transition/phase_2_to_3/tick/attack/pillar/alert
     execute if score @s General.Mob.Tick matches 570 at @e[type=marker,tag=RW.Marker.Aim,sort=nearest,limit=1] run function asset:mob/1004.tultaria/tick/skill/transition/phase_2_to_3/tick/attack/pillar/summon
 
 # TODO: デバッグ用につき後で消すこと


### PR DESCRIPTION
- ランダムなプレイヤーの選択時に、範囲無制限、ディメンション関係なしで選択できてしまうのを修正。
- 上記の修正により、一部行動時に動作を完全停止してしまう問題も治るはずです