### PR TITLE
:bug: [Artifact 1055] コール: エレメンタルファミリアで召喚される Mob が友好 Mob 扱いされていない問題を修正

### DIFF
--- a/Asset/data/asset/functions/object/1055.elemental_fish/summon/.mcfunction
+++ b/Asset/data/asset/functions/object/1055.elemental_fish/summon/.mcfunction
@@ -5,4 +5,4 @@
 # @within asset:object/alias/1055/summon
 
 # 元となるEntityを召喚する
-    summon item_display ~ ~ ~ {Tags:["ObjectInit"],item_display:"head",teleport_duration:1,transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,0f,0f],scale:[0.5f,0.5f,0.5f]}}
+    summon item_display ~ ~ ~ {Tags:["ObjectInit","Friend"],item_display:"head",teleport_duration:1,transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,0f,0f],scale:[0.5f,0.5f,0.5f]}}


### PR DESCRIPTION
Fix #864