### PR TITLE
[神器898] 疾風のペンダントの調整

### DIFF
--- a/Asset/data/asset/functions/artifact/0898.gale_pendant/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0898.gale_pendant/give/2.give.mcfunction
@@ -13,7 +13,7 @@
 # 神器のベースアイテム
     data modify storage asset:artifact Item set value "minecraft:stick"
 # 神器の名前 (TextComponentString)
-    data modify storage asset:artifact Name set value '{"text":"疾風のペンダント","color":"aqua"}'
+    data modify storage asset:artifact Name set value '{"text":"疾風のペンダント","color":"#8ff0dc"}'
 # 神器の説明文 (TextComponentString[])
     data modify storage asset:artifact Lore set value ['{"text":"非戦闘時、移動速度が大きく上昇する。","color":"white"}','{"text":"風の力を蓄えたペンダント。","color":"gray"}','{"text":"付けると体が軽くなる。","color":"gray"}']
 # 消費アイテム ({Item: TextComponent, Count: int, Extra?: TextComponent}) (オプション)

--- a/Asset/data/asset/functions/artifact/0898.gale_pendant/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0898.gale_pendant/give/2.give.mcfunction
@@ -58,7 +58,7 @@
 # MP不足による使用不可のメッセージを非表示にするか否か (boolean) (オプション)
     # data modify storage asset:artifact DisableMPMessage set value
 # 扱える神 (string[]) Wikiを参照
-    data modify storage asset:artifact CanUsedGod set value ["Flora", "Urban", "Nyaptov", "Wi-ki", "Rumor"]
+    data modify storage asset:artifact CanUsedGod set value "ALL"
 # カスタムNBT (NBTCompound) 追加で指定したいNBT (オプション)
     data modify storage asset:artifact CustomNBT set value {Enchantments:[{}]}
 

--- a/Asset/data/asset/functions/artifact/0898.gale_pendant/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0898.gale_pendant/give/2.give.mcfunction
@@ -58,7 +58,7 @@
 # MP不足による使用不可のメッセージを非表示にするか否か (boolean) (オプション)
     # data modify storage asset:artifact DisableMPMessage set value
 # 扱える神 (string[]) Wikiを参照
-    data modify storage asset:artifact CanUsedGod set value ["Flora", "Nyaptov"]
+    data modify storage asset:artifact CanUsedGod set value ["Flora", "Urban", "Nyaptov", "Wi-ki", "Rumor"]
 # カスタムNBT (NBTCompound) 追加で指定したいNBT (オプション)
     data modify storage asset:artifact CustomNBT set value {Enchantments:[{}]}
 


### PR DESCRIPTION
・全信仰で使用可能に
・名前の色を調整