### PR TITLE
🚸 [Artifact 87] 羊の加護がライトブロックを置き換えられないのを修正

### DIFF
--- a/Asset/data/asset/functions/effect/0202.sheep_blessing/tick/.mcfunction
+++ b/Asset/data/asset/functions/effect/0202.sheep_blessing/tick/.mcfunction
@@ -2,4 +2,4 @@
 # @within function asset:effect/0202.sheep_blessing/_/tick
 
 # 破壊可能エリアかつスペクテイターでなければ羊毛の床を設置
-    execute if predicate api:area/is_breakable if entity @s[gamemode=!spectator] run fill ~-1 ~-1 ~-1 ~1 ~-1 ~1 white_wool keep
+    execute if predicate api:area/is_breakable if entity @s[gamemode=!spectator] run fill ~-1 ~-1 ~-1 ~1 ~-1 ~1 white_wool replace #lib:air


### PR DESCRIPTION
Fix #880