### PR TITLE
🚸 [Mob 53] 処刑人が負傷時にエフェクトの靄を出さないように修正 及び 索敵範囲の調整

### DIFF
--- a/Asset/data/asset/functions/mob/0053.executioners/hurt/.mcfunction
+++ b/Asset/data/asset/functions/mob/0053.executioners/hurt/.mcfunction
@@ -5,4 +5,4 @@
 # @within function asset:mob/alias/53/hurt
 
 # 確立でバックステップする
-    execute if predicate lib:random_pass_per/50 run function asset:mob/0053.executioners/hurt/2.1.backstep
+    execute if predicate lib:random_pass_per/50 run function asset:mob/0053.executioners/hurt/backstep

--- a/Asset/data/asset/functions/mob/0053.executioners/hurt/backstep.mcfunction
+++ b/Asset/data/asset/functions/mob/0053.executioners/hurt/backstep.mcfunction
@@ -12,7 +12,7 @@
     execute facing entity @p[tag=Attacker,distance=..100] feet rotated ~180 -10 run function lib:motion/
 
 # エフェクト
-    effect give @s speed 1 6
+    effect give @s speed 1 6 true
 
 # リセット
     data remove storage lib: Argument

--- a/Asset/data/asset/functions/mob/0053.executioners/hurt/backstep.mcfunction
+++ b/Asset/data/asset/functions/mob/0053.executioners/hurt/backstep.mcfunction
@@ -1,4 +1,4 @@
-#> asset:mob/0053.executioners/hurt/2.1.backstep
+#> asset:mob/0053.executioners/hurt/backstep
 #
 # バックステップ（ほとんどチェーンソーゾンビと一緒）
 #

--- a/Asset/data/asset/functions/mob/0053.executioners/register.mcfunction
+++ b/Asset/data/asset/functions/mob/0053.executioners/register.mcfunction
@@ -38,7 +38,7 @@
 # 移動速度 (double) (オプション)
     data modify storage asset:mob Speed set value 0.25
 # 索敵範囲 (double) (オプション)
-    data modify storage asset:mob FollowRange set value 100
+    data modify storage asset:mob FollowRange set value 32
 # ノックバック耐性 (double) (オプション)
     data modify storage asset:mob KnockBackResist set value 0.875
 # 属性倍率 // 1.0fで100% 最低でも25%は軽減されずに入る


### PR DESCRIPTION
Fix #868