### PR TITLE
[Artifact1047] 魂命の徽章の修正

### DIFF
--- a/Asset/data/asset/functions/artifact/1047.life_steal_emblem/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/1047.life_steal_emblem/give/2.give.mcfunction
@@ -15,7 +15,7 @@
 # 神器の名前 (TextComponentString)
     data modify storage asset:artifact Name set value '{"text":"魂命の徽章","color":"dark_aqua","bold":true}'
 # 神器の説明文 (TextComponentString[])
-    data modify storage asset:artifact Lore set value ['[{"text":"最大HPの25%を失うかわりに","color":"white"},{"text":"物理攻撃","color":"dark_green"},{"text":"を大幅に強化する","color":"white"}]','[{"text":"失うHPが多ければ多いほど","color":"white"},{"text":"物理攻撃","color":"dark_green"},{"text":"が上がる","color":"white"}]','{"text":"命を燃やせば燃やすほど人は輝くものだ","color":"gray","italic":true}']
+    data modify storage asset:artifact Lore set value ['[{"text":"最大HPの25%分のダメージを受ける代わりに","color":"white"}]','[{"text":"最大HPの8%分の","color":"white"},{"text":"物理攻撃","color":"dark_green"},{"text":"バフを20秒間得る","color":"white"}]','{"text":"命を燃やせば燃やすほど人は輝くものだ","color":"gray","italic":true}']
 # 消費アイテム ({Item: TextComponent, Count: int, Extra?: TextComponent}) (オプション)
     # data modify storage asset:artifact ConsumeItem.Item set value
     # data modify storage asset:artifact ConsumeItem.Count set value
@@ -27,7 +27,7 @@
 # 神器のトリガー (string) Wikiを参照
     data modify storage asset:artifact Trigger set value "onClick"
 # 神器の発動条件 (TextComponentString) (オプション)
-    data modify storage asset:artifact Condition set value '[{"text":"現在HPが最大HPの25%以上、残っている時"}]'
+    data modify storage asset:artifact Condition set value '[{"text":"HPが25%以上"}]'
 # 攻撃に関する情報 -Damage量 (literal[]/literal) Wikiを参照 (オプション)
     # data modify storage asset:artifact AttackInfo.Damage set value [0,0]
 # 攻撃に関する情報 -攻撃タイプ (string[]) Wikiを参照 (オプション)

--- a/Asset/data/asset/functions/artifact/1047.life_steal_emblem/trigger/0.load.mcfunction
+++ b/Asset/data/asset/functions/artifact/1047.life_steal_emblem/trigger/0.load.mcfunction
@@ -1,9 +1,0 @@
-#> asset:artifact/1047.life_steal_emblem/trigger/0.load
-#
-# 神器に利用するスコアボード等の初期化処理
-#
-# @within tag/function asset:artifact/load
-
-#> 定義類はここに
-# @within function asset:artifact/1047.life_steal_emblem/trigger/**
-    scoreboard objectives add T3.BuffTick dummy

--- a/Asset/data/asset/functions/artifact/1047.life_steal_emblem/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/1047.life_steal_emblem/trigger/3.main.mcfunction
@@ -26,6 +26,9 @@
     function api:damage/reset
 
 # 魂命バフを付与する
+# Amount = 最大HPの8%
+# 100の時に8%
     data modify storage api: Argument.ID set value 260
+    execute store result storage api: Argument.FieldOverride.Amount double 0.0008 run data get storage api: Return.MaxHealth
     function api:entity/mob/effect/give
     function api:entity/mob/effect/reset

--- a/Asset/data/asset/functions/effect/0260.life_steal/modifier/add.mcfunction
+++ b/Asset/data/asset/functions/effect/0260.life_steal/modifier/add.mcfunction
@@ -6,10 +6,8 @@
 #   asset:effect/0260.life_steal/given/
 #   asset:effect/0260.life_steal/re-given/
 
-# 物理攻撃 + (最大HP * 0.14%)
-# 最大HPが100の時に+14%
+# 物理攻撃
     data modify storage api: Argument.UUID set value [I;1,3,260,0]
-    function api:modifier/max_health/get
-    execute store result storage api: Argument.Amount double 0.0008 run data get storage api: Return.MaxHealth
+    data modify storage api: Argument.Amount set from storage asset:context this.Amount
     data modify storage api: Argument.Operation set value "multiply"
     function api:modifier/attack/physical/add

--- a/Asset/data/asset/functions/effect/0260.life_steal/register.mcfunction
+++ b/Asset/data/asset/functions/effect/0260.life_steal/register.mcfunction
@@ -36,4 +36,4 @@
     data modify storage asset:effect StackVisible set value false
 
 # フィールド
-    # data modify storage asset:effect Field set value {}
+    data modify storage asset:effect Field.Amount set value 0.05

--- a/Asset/data/asset/tags/functions/artifact/load.json
+++ b/Asset/data/asset/tags/functions/artifact/load.json
@@ -14,7 +14,6 @@
         "asset:artifact/0837.the_world_knife/trigger/0.load",
         "asset:artifact/0600.xtal/trigger/0.load",
         "asset:artifact/0664.soul_fire_armor/trigger/0.load",
-        "asset:artifact/1047.life_steal_emblem/trigger/0.load",
         "asset:artifact/1048.thunder_storm/trigger/0.load",
         "asset:artifact/1057.great_demon_head/trigger/0.load",
         "asset:artifact/1045.mini_black_hole/trigger/0.load",


### PR DESCRIPTION
・不要なloadを破壊
・説明を修正
・補正量の計算を神器側で行い、Effect側にFieldOverrideを使って渡すように