### PR TITLE
[Mob0154] 破滅の演出の調整

### DIFF
--- a/Asset/data/asset/functions/mob/0154.ruin/hurt/.mcfunction
+++ b/Asset/data/asset/functions/mob/0154.ruin/hurt/.mcfunction
@@ -5,6 +5,6 @@
 # @within function asset:mob/alias/154/hurt
 
 # 演出
-    particle dragon_breath ~ ~1.2 ~ 0.4 0.4 0.4 0.05 25
+    particle dragon_breath ~ ~1.2 ~ 0.4 0.4 0.4 0.05 5
     playsound entity.warden.attack_impact hostile @a ~ ~ ~ 1 0.7
     playsound entity.warden.attack_impact hostile @a ~ ~ ~ 1 0.5


### PR DESCRIPTION
流石に連射系で見えなくなるのはやばい