### PR TITLE
[Mob0187] フレイムメイジにAlawaySlowFallを追加

### DIFF
--- a/Asset/data/asset/functions/mob/0187.flame_mage/summon/.mcfunction
+++ b/Asset/data/asset/functions/mob/0187.flame_mage/summon/.mcfunction
@@ -5,4 +5,4 @@
 # @within asset:mob/alias/187/summon
 
 # 元となるMobを召喚する
-    summon zombie ~ ~ ~ {Silent:1b,Tags:["MobInit","AlwaysInvisible"],DeathLootTable:"empty"}
+    summon zombie ~ ~ ~ {Silent:1b,Tags:["MobInit","AlwaysInvisible","AlwaysSlowFall"],DeathLootTable:"empty"}


### PR DESCRIPTION
ウォーターとサンダーには合ったのにフレイムにはなかった、なんで？