### PR TITLE
[Effect0295] 破壊の手のIDの移動

### DIFF
--- a/Asset/data/asset/functions/artifact/1084.mia_zoru_luc/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/1084.mia_zoru_luc/trigger/3.main.mcfunction
@@ -14,6 +14,6 @@
     particle block redstone_block ~ ~1.3 ~ 0 0 0 1 20
 
 # エフェクトを付与
-    data modify storage api: Argument.ID set value 619
+    data modify storage api: Argument.ID set value 295
     function api:entity/mob/effect/give
     function api:entity/mob/effect/reset

--- a/Asset/data/asset/functions/artifact/1084.mia_zoru_luc/trigger/dis_equip/main.mcfunction
+++ b/Asset/data/asset/functions/artifact/1084.mia_zoru_luc/trigger/dis_equip/main.mcfunction
@@ -5,6 +5,6 @@
 # @within function asset:artifact/1084.mia_zoru_luc/trigger/dis_equip/
 
 # エフェクトを削除
-    data modify storage api: Argument.ID set value 619
+    data modify storage api: Argument.ID set value 295
     function api:entity/mob/effect/remove/from_id
     function api:entity/mob/effect/reset

--- a/Asset/data/asset/functions/effect/0295.hand_of_destruction/_/end.mcfunction
+++ b/Asset/data/asset/functions/effect/0295.hand_of_destruction/_/end.mcfunction
@@ -1,0 +1,7 @@
+#> asset:effect/0295.hand_of_destruction/_/end
+#
+# Effectの効果の終了時に実行されるfunction
+#
+# @within tag/function asset:effect/end
+
+execute if data storage asset:context {id:295} run function asset:effect/0295.hand_of_destruction/end/

--- a/Asset/data/asset/functions/effect/0295.hand_of_destruction/_/register.mcfunction
+++ b/Asset/data/asset/functions/effect/0295.hand_of_destruction/_/register.mcfunction
@@ -1,0 +1,7 @@
+#> asset:effect/0295.hand_of_destruction/_/register
+#
+#
+#
+# @within tag/function asset:effect/register
+
+execute if data storage asset:context {id:295} run function asset:effect/0295.hand_of_destruction/register

--- a/Asset/data/asset/functions/effect/0295.hand_of_destruction/_/remove.mcfunction
+++ b/Asset/data/asset/functions/effect/0295.hand_of_destruction/_/remove.mcfunction
@@ -1,0 +1,7 @@
+#> asset:effect/0295.hand_of_destruction/_/remove
+#
+# Effectが神器や牛乳によって削除された時に実行されるfunction
+#
+# @within tag/function asset:effect/remove
+
+execute if data storage asset:context {id:295} run function asset:effect/0295.hand_of_destruction/remove/

--- a/Asset/data/asset/functions/effect/0295.hand_of_destruction/_/tick.mcfunction
+++ b/Asset/data/asset/functions/effect/0295.hand_of_destruction/_/tick.mcfunction
@@ -1,0 +1,7 @@
+#> asset:effect/0295.hand_of_destruction/_/tick
+#
+# Effectが発動している間毎tick実行されるfunction
+#
+# @within tag/function asset:effect/tick
+
+execute if data storage asset:context {id:295} run function asset:effect/0295.hand_of_destruction/tick/

--- a/Asset/data/asset/functions/effect/0295.hand_of_destruction/end/.mcfunction
+++ b/Asset/data/asset/functions/effect/0295.hand_of_destruction/end/.mcfunction
@@ -1,0 +1,7 @@
+#> asset:effect/0295.hand_of_destruction/end/
+#
+# Effectの効果が切れた時の処理
+#
+# @within function asset:effect/0295.hand_of_destruction/_/end
+
+effect clear @s haste

--- a/Asset/data/asset/functions/effect/0295.hand_of_destruction/register.mcfunction
+++ b/Asset/data/asset/functions/effect/0295.hand_of_destruction/register.mcfunction
@@ -1,13 +1,13 @@
-#> asset:effect/0619.hand_of_destruction/register
+#> asset:effect/0295.hand_of_destruction/register
 #
 # Effectのデータを指定
 #
-# @within function asset:effect/0619.hand_of_destruction/_/register
+# @within function asset:effect/0295.hand_of_destruction/_/register
 
 # ExtendsSafe (boolean) (default = false)
     # data modify storage asset:effect ExtendsSafe set value true
 # ID (int)
-    data modify storage asset:effect ID set value 619
+    data modify storage asset:effect ID set value 295
 # 名前 (TextComponentString)
     data modify storage asset:effect Name set value '{"text":"破壊の手"}'
 # 説明文 (TextComponentString[])

--- a/Asset/data/asset/functions/effect/0295.hand_of_destruction/remove/.mcfunction
+++ b/Asset/data/asset/functions/effect/0295.hand_of_destruction/remove/.mcfunction
@@ -1,0 +1,7 @@
+#> asset:effect/0295.hand_of_destruction/remove/
+#
+# Effectが削除された時の処理
+#
+# @within function asset:effect/0295.hand_of_destruction/_/remove
+
+effect clear @s haste

--- a/Asset/data/asset/functions/effect/0295.hand_of_destruction/tick/.mcfunction
+++ b/Asset/data/asset/functions/effect/0295.hand_of_destruction/tick/.mcfunction
@@ -1,0 +1,7 @@
+#> asset:effect/0295.hand_of_destruction/tick/
+#
+# Effectのtick処理
+#
+# @within function asset:effect/0295.hand_of_destruction/_/tick
+
+effect give @s haste infinite 3 true

--- a/Asset/data/asset/functions/effect/0619.hand_of_destruction/_/end.mcfunction
+++ b/Asset/data/asset/functions/effect/0619.hand_of_destruction/_/end.mcfunction
@@ -1,7 +1,0 @@
-#> asset:effect/0619.hand_of_destruction/_/end
-#
-# Effectの効果の終了時に実行されるfunction
-#
-# @within tag/function asset:effect/end
-
-execute if data storage asset:context {id:619} run function asset:effect/0619.hand_of_destruction/end/

--- a/Asset/data/asset/functions/effect/0619.hand_of_destruction/_/register.mcfunction
+++ b/Asset/data/asset/functions/effect/0619.hand_of_destruction/_/register.mcfunction
@@ -1,7 +1,0 @@
-#> asset:effect/0619.hand_of_destruction/_/register
-#
-#
-#
-# @within tag/function asset:effect/register
-
-execute if data storage asset:context {id:619} run function asset:effect/0619.hand_of_destruction/register

--- a/Asset/data/asset/functions/effect/0619.hand_of_destruction/_/remove.mcfunction
+++ b/Asset/data/asset/functions/effect/0619.hand_of_destruction/_/remove.mcfunction
@@ -1,7 +1,0 @@
-#> asset:effect/0619.hand_of_destruction/_/remove
-#
-# Effectが神器や牛乳によって削除された時に実行されるfunction
-#
-# @within tag/function asset:effect/remove
-
-execute if data storage asset:context {id:619} run function asset:effect/0619.hand_of_destruction/remove/

--- a/Asset/data/asset/functions/effect/0619.hand_of_destruction/_/tick.mcfunction
+++ b/Asset/data/asset/functions/effect/0619.hand_of_destruction/_/tick.mcfunction
@@ -1,7 +1,0 @@
-#> asset:effect/0619.hand_of_destruction/_/tick
-#
-# Effectが発動している間毎tick実行されるfunction
-#
-# @within tag/function asset:effect/tick
-
-execute if data storage asset:context {id:619} run function asset:effect/0619.hand_of_destruction/tick/

--- a/Asset/data/asset/functions/effect/0619.hand_of_destruction/end/.mcfunction
+++ b/Asset/data/asset/functions/effect/0619.hand_of_destruction/end/.mcfunction
@@ -1,7 +1,0 @@
-#> asset:effect/0619.hand_of_destruction/end/
-#
-# Effectの効果が切れた時の処理
-#
-# @within function asset:effect/0619.hand_of_destruction/_/end
-
-effect clear @s haste

--- a/Asset/data/asset/functions/effect/0619.hand_of_destruction/remove/.mcfunction
+++ b/Asset/data/asset/functions/effect/0619.hand_of_destruction/remove/.mcfunction
@@ -1,7 +1,0 @@
-#> asset:effect/0619.hand_of_destruction/remove/
-#
-# Effectが削除された時の処理
-#
-# @within function asset:effect/0619.hand_of_destruction/_/remove
-
-effect clear @s haste

--- a/Asset/data/asset/functions/effect/0619.hand_of_destruction/tick/.mcfunction
+++ b/Asset/data/asset/functions/effect/0619.hand_of_destruction/tick/.mcfunction
@@ -1,7 +1,0 @@
-#> asset:effect/0619.hand_of_destruction/tick/
-#
-# Effectのtick処理
-#
-# @within function asset:effect/0619.hand_of_destruction/_/tick
-
-effect give @s haste infinite 3 true

--- a/Asset/data/asset/tags/functions/effect/end.json
+++ b/Asset/data/asset/tags/functions/effect/end.json
@@ -52,7 +52,7 @@
         "asset:effect/0269.pain_and_sweet/_/end",
         "asset:effect/0265.light_of_firefly/_/end",
         "asset:effect/0267.dreaming_veil/_/end",
-        "asset:effect/0619.hand_of_destruction/_/end",
+        "asset:effect/0295.hand_of_destruction/_/end",
         "asset:effect/0261.gale_blessing/_/end",
         "asset:effect/0210.fading_speed/_/end",
         "asset:effect/0211.fading_speed/_/end",

--- a/Asset/data/asset/tags/functions/effect/register.json
+++ b/Asset/data/asset/tags/functions/effect/register.json
@@ -75,7 +75,7 @@
         "asset:effect/0270.honey_regeneration/_/register",
         "asset:effect/0265.light_of_firefly/_/register",
         "asset:effect/0267.dreaming_veil/_/register",
-        "asset:effect/0619.hand_of_destruction/_/register",
+        "asset:effect/0295.hand_of_destruction/_/register",
         "asset:effect/0261.gale_blessing/_/register",
         "asset:effect/0210.fading_speed/_/register",
         "asset:effect/0211.fading_speed/_/register",

--- a/Asset/data/asset/tags/functions/effect/remove.json
+++ b/Asset/data/asset/tags/functions/effect/remove.json
@@ -50,7 +50,7 @@
         "asset:effect/0269.pain_and_sweet/_/remove",
         "asset:effect/0265.light_of_firefly/_/remove",
         "asset:effect/0267.dreaming_veil/_/remove",
-        "asset:effect/0619.hand_of_destruction/_/remove",
+        "asset:effect/0295.hand_of_destruction/_/remove",
         "asset:effect/0261.gale_blessing/_/remove",
         "asset:effect/0210.fading_speed/_/remove",
         "asset:effect/0211.fading_speed/_/remove",

--- a/Asset/data/asset/tags/functions/effect/tick.json
+++ b/Asset/data/asset/tags/functions/effect/tick.json
@@ -51,7 +51,7 @@
         "asset:effect/0269.pain_and_sweet/_/tick",
         "asset:effect/0270.honey_regeneration/_/tick",
         "asset:effect/0265.light_of_firefly/_/tick",
-        "asset:effect/0619.hand_of_destruction/_/tick",
+        "asset:effect/0295.hand_of_destruction/_/tick",
         "asset:effect/0261.gale_blessing/_/tick",
         "asset:effect/0210.fading_speed/_/tick",
         "asset:effect/0276.unending_thunder/_/tick",


### PR DESCRIPTION
619 → 295
Fix #499