### PR TITLE
:balance_scale: [Artifact 1176] B.L.E.S.S.のダメージと挙動の改善及び神器名の修正

### DIFF
--- a/Asset/data/asset/functions/artifact/1176.b_l_e_s_s/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/1176.b_l_e_s_s/give/2.give.mcfunction
@@ -13,7 +13,7 @@
 # 神器のベースアイテム
     data modify storage asset:artifact Item set value "minecraft:carrot_on_a_stick"
 # 神器の名前 (TextComponentString)
-    data modify storage asset:artifact Name set value '{"text":"B.L.E.S.S","color":"aqua"}'
+    data modify storage asset:artifact Name set value '{"text":"B.L.E.S.S.","color":"aqua"}'
 # 神器の説明文 (TextComponentString[])
     data modify storage asset:artifact Lore set value ['{"text":"クロスヘアに捉えた敵に向かってミサイルを発射する。","color":"white"}','{"text":"発射時の姿勢によってミサイルの性質が変化する。","color":"white"}','{"text":" スニーク：火属性の範囲ダメージ","color":"white"}','{"text":" 直立：耐性貫通の無属性単体ダメージ","color":"white"}','{"text":"ミサイルが一定距離飛翔すると最大火力となる。","color":"white"}','{"text":"?「正式名称は両用支援打撃弾","color":"dark_aqua","italic":true}','{"text":"(Bipurpose Launching Equipment for Support Strike)","color":"dark_aqua","italic":true}','{"text":"撃つも殴るもよし、対地対空両用の万能な兵器。","color":"dark_aqua","italic":true}','{"text":"魔力と適正さえあれば人でも天使でも、誰でも簡単に扱える。」","color":"dark_aqua","italic":true}']
 

--- a/Asset/data/asset/functions/artifact/1176.b_l_e_s_s/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/1176.b_l_e_s_s/give/2.give.mcfunction
@@ -30,7 +30,7 @@
 # 神器の発動条件 (TextComponentString) (オプション)
     # data modify storage asset:artifact Condition set value 
 # 攻撃に関する情報 -Damage量 (literal[]/literal) Wikiを参照 (オプション)
-    data modify storage asset:artifact AttackInfo.Damage set value ["600/1100","3000/5500"]
+    data modify storage asset:artifact AttackInfo.Damage set value ["520/840","2600/4200"]
 # 攻撃に関する情報 -攻撃タイプ (string[]) Wikiを参照 (オプション)
     data modify storage asset:artifact AttackInfo.AttackType set value [Physical]
 # 攻撃に関する情報 -攻撃属性 (string[]) Wikiを参照 (オプション)
@@ -42,16 +42,16 @@
 # 攻撃に関する情報 -攻撃範囲 (literal) Wikiを参照 (オプション)
     data modify storage asset:artifact AttackInfo.AttackRange set value 50
 # MP消費量 (int) 
-    data modify storage asset:artifact MPCost set value 300
+    data modify storage asset:artifact MPCost set value 220
 # MP必要量 (int) (オプション)
     # data modify storage asset:artifact MPRequire set value 
 # MP回復量 (int) 
     # data modify storage asset:artifact MPHealWhenHit set value 
 # 神器のクールダウン (int) (オプション)
-    data modify storage asset:artifact LocalCooldown set value 100
+    data modify storage asset:artifact LocalCooldown set value 240
 # 種別クールダウン ({Type: string, Duration: int}) (オプション)
     data modify storage asset:artifact TypeCooldown.Type set value "longRange"
-    data modify storage asset:artifact TypeCooldown.Duration set value 60
+    data modify storage asset:artifact TypeCooldown.Duration set value 100
 # グローバルクールダウン (int) (オプション)
     # data modify storage asset:artifact SpecialCooldown set value 
 # クールダウンによる使用不可のメッセージを非表示にするか否か (boolean) (オプション)

--- a/Asset/data/asset/functions/artifact/1176.b_l_e_s_s/trigger/2.check_condition.mcfunction
+++ b/Asset/data/asset/functions/artifact/1176.b_l_e_s_s/trigger/2.check_condition.mcfunction
@@ -10,6 +10,7 @@
 # ターゲット選定
     scoreboard players set $WO.TargetID Temporary 0
     function asset:artifact/1176.b_l_e_s_s/trigger/select_target
+    execute if score $WO.TargetID Temporary matches 0 run tellraw @s [{"text": "ターゲットがいません","color": "red"}]
     execute if score $WO.TargetID Temporary matches 0 run tag @s remove CanUsed
     
 # CanUsedタグをチェックして3.main.mcfunctionを実行する

--- a/Asset/data/asset/functions/artifact/1176.b_l_e_s_s/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/1176.b_l_e_s_s/trigger/3.main.mcfunction
@@ -10,12 +10,12 @@
 
 # 発射
     execute if predicate lib:is_sneaking run data modify storage api: Argument.ID set value 1094
-    execute if predicate lib:is_sneaking run data modify storage api: Argument.FieldOverride.InitMotionDamage set value 600f
-    execute if predicate lib:is_sneaking run data modify storage api: Argument.FieldOverride.MaxDamage set value 3000f
+    execute if predicate lib:is_sneaking run data modify storage api: Argument.FieldOverride.InitMotionDamage set value 520f
+    execute if predicate lib:is_sneaking run data modify storage api: Argument.FieldOverride.MaxDamage set value 2600
 
     execute unless predicate lib:is_sneaking run data modify storage api: Argument.ID set value 1095
-    execute unless predicate lib:is_sneaking run data modify storage api: Argument.FieldOverride.InitMotionDamage set value 800f
-    execute unless predicate lib:is_sneaking run data modify storage api: Argument.FieldOverride.MaxDamage set value 4000f
+    execute unless predicate lib:is_sneaking run data modify storage api: Argument.FieldOverride.InitMotionDamage set value 820f
+    execute unless predicate lib:is_sneaking run data modify storage api: Argument.FieldOverride.MaxDamage set value 4200f
 
     execute store result storage api: Argument.FieldOverride.TargetID int 1 run scoreboard players get $WO.TargetID Temporary
     execute store result storage api: Argument.FieldOverride.UserID int 1 run scoreboard players get @s UserID

--- a/Asset/data/asset/functions/artifact/1176.b_l_e_s_s/trigger/select_target.mcfunction
+++ b/Asset/data/asset/functions/artifact/1176.b_l_e_s_s/trigger/select_target.mcfunction
@@ -7,7 +7,7 @@
 
 
 # クロスヘア中心15度以内のエンティティにタグ付け
-    execute anchored eyes positioned ^ ^ ^25 as @e[type=#lib:living,tag=Enemy,tag=!Uninterferable,distance=..25] positioned as @s facing entity @p[tag=this] eyes positioned ^ ^ ^1000 rotated as @p[tag=this] positioned ^ ^ ^1000 if entity @s[distance=..261.1] run tag @s add WO.Candidate
+    execute anchored eyes positioned ^ ^ ^25 as @e[type=#lib:living,tag=Enemy,tag=!Uninterferable,distance=..25] positioned as @s facing entity @p[tag=this] feet positioned ^ ^ ^1000 rotated as @p[tag=this] positioned ^ ^ ^1000 if entity @s[distance=..261.1] run tag @s add WO.Candidate
         #execute if entity @e[type=#lib:living,tag=Enemy,tag=WO.Candidate,tag=!Uninterferable] run say detect
         #execute unless entity @e[type=#lib:living,tag=Enemy,tag=WO.Candidate,tag=!Uninterferable] run say nodetect
 

--- a/Asset/data/asset/functions/object/1094.aa_missile/register.mcfunction
+++ b/Asset/data/asset/functions/object/1094.aa_missile/register.mcfunction
@@ -20,5 +20,5 @@
 # フィールド(オプション)　
     data modify storage asset:object Field.TargetID set value 0
     data modify storage asset:object Field.UserID set value 0
-    data modify storage asset:object Field.MaxDamage set value 3000f
-    data modify storage asset:object Field.InitMotionDamage set value 600f
+    data modify storage asset:object Field.MaxDamage set value 0f
+    data modify storage asset:object Field.InitMotionDamage set value 0f

--- a/Asset/data/asset/functions/object/1095.ag_missile/register.mcfunction
+++ b/Asset/data/asset/functions/object/1095.ag_missile/register.mcfunction
@@ -19,5 +19,5 @@
 # フィールド(オプション)
     data modify storage asset:object Field.TargetID set value 0
     data modify storage asset:object Field.UserID set value 0
-    data modify storage asset:object Field.MaxDamage set value 4000f
-    data modify storage asset:object Field.InitMotionDamage set value 800f
+    data modify storage asset:object Field.MaxDamage set value 0f
+    data modify storage asset:object Field.InitMotionDamage set value 0f

--- a/Asset/data/asset/functions/object/1095.ag_missile/tick/.mcfunction
+++ b/Asset/data/asset/functions/object/1095.ag_missile/tick/.mcfunction
@@ -4,6 +4,12 @@
 #
 # @within asset:object/alias/1095/tick
 
+#> seeker_check
+# @within
+#   function asset:object/1095.ag_missile/tick/
+#   function asset:object/1095.ag_missile/tick/target_check
+    #declare tag TargetOutOfSight
+
 # Tick加算
     scoreboard players add @s General.Object.Tick 1
 
@@ -13,9 +19,13 @@
 # 加速開始音
     execute if score @s General.Object.Tick matches 7 run playsound minecraft:entity.breeze.death neutral @a[distance=..16] ~ ~ ~ 2 0.5 1
 
+# 上昇モーションを終了させるべきかどうかのチェック
+    function asset:object/1095.ag_missile/tick/target_check with storage asset:context this
+
 # 加速時の移動
-    execute if score @s General.Object.Tick matches 7..12 run function asset:object/1095.ag_missile/tick/accel_motion1 with storage asset:context this
-    execute if score @s General.Object.Tick matches 13..26 run function asset:object/1095.ag_missile/tick/accel_motion2 with storage asset:context this
+    execute unless entity @s[tag=TargetOutOfSight] if score @s General.Object.Tick matches 7..12 run function asset:object/1095.ag_missile/tick/accel_motion1 with storage asset:context this
+    execute unless entity @s[tag=TargetOutOfSight] if score @s General.Object.Tick matches 13..26 run function asset:object/1095.ag_missile/tick/accel_motion2 with storage asset:context this
+    execute if entity @s[tag=TargetOutOfSight] if score @s General.Object.Tick matches 7..26 run function asset:object/1095.ag_missile/tick/accel_motion3 with storage asset:context this
 
 # 加速後の移動
     execute if score @s General.Object.Tick matches 27.. run function asset:object/1095.ag_missile/tick/inertia_motion with storage asset:context this

--- a/Asset/data/asset/functions/object/1095.ag_missile/tick/accel_motion3.mcfunction
+++ b/Asset/data/asset/functions/object/1095.ag_missile/tick/accel_motion3.mcfunction
@@ -1,0 +1,12 @@
+#> asset:object/1095.ag_missile/tick/accel_motion3
+#
+# 
+#
+# @within function asset:object/1095.ag_missile/tick/
+
+# 移動
+    $execute facing entity @e[type=#lib:living,scores={MobUUID=$(TargetID)},distance=..128] eyes run tp @s ^ ^ ^0.7 ~ ~
+
+# particle
+    particle minecraft:cloud ^ ^ ^-1 0.1 0.1 0.1 0.03 1
+    particle minecraft:flame ^ ^ ^-1 0.1 0.1 0.1 0.001 1

--- a/Asset/data/asset/functions/object/1095.ag_missile/tick/target_check.mcfunction
+++ b/Asset/data/asset/functions/object/1095.ag_missile/tick/target_check.mcfunction
@@ -1,0 +1,9 @@
+#> asset:object/1095.ag_missile/tick/target_check
+#
+# ターゲットが視界外にいるかチェック、視界外だったら強制的に当たりに行くフラグをたてる
+#
+# @within function asset:object/1095.ag_missile/tick/
+
+# 対象が左右45度の角度内にいるかチェック
+    $execute facing entity @e[type=#lib:living,scores={MobUUID=$(TargetID)},distance=..128,limit=1] eyes positioned ^ ^ ^4 rotated as @s rotated ~45 0 positioned ^-3 ^ ^ unless entity @s[distance=..5] run tag @s add TargetOutOfSight
+    $execute facing entity @e[type=#lib:living,scores={MobUUID=$(TargetID)},distance=..128,limit=1] eyes positioned ^ ^ ^4 rotated as @s rotated ~-45 0 positioned ^3 ^ ^ unless entity @s[distance=..5] run tag @s add TargetOutOfSight


### PR DESCRIPTION
- バランス調整データ反映
- 敵がミサイル前方から外れたら強制的に当たりに行くようにして挙動の違和感削減
- 神器名修正