### PR TITLE
🐛 [Artifact 605] 下克上の演出処理のミスを修正

### DIFF
--- a/Asset/data/asset/functions/artifact/0605.ambition/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/0605.ambition/trigger/3.main.mcfunction
@@ -15,7 +15,7 @@
 # 没収されたアイテム * 11の値を設定
     scoreboard players operation @s Temporary *= $11 Const
 
-# 最大値をきめる
+# ダメージ最大値設定
     scoreboard players set $MaxDamage Temporary 4400
 
 # 演出

--- a/Asset/data/asset/functions/artifact/0605.ambition/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/0605.ambition/trigger/3.main.mcfunction
@@ -17,12 +17,13 @@
 
 # ダメージ最大値設定
     scoreboard players set $MaxDamage Temporary 4400
+    scoreboard players operation @s Temporary < $MaxDamage Temporary
 
 # 演出
     execute at @e[type=#lib:living,type=!player,tag=Victim,distance=..6] positioned ~ ~1 ~ summon marker run function asset:artifact/0605.ambition/trigger/vfx/
 
 # ダメージ
-    execute store result storage api: Argument.Damage float 1 run scoreboard players operation @s Temporary < $MaxDamage Temporary
+    execute store result storage api: Argument.Damage float 1 run scoreboard players get @s Temporary
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/artifact/0605.ambition/trigger/vfx/.mcfunction
+++ b/Asset/data/asset/functions/artifact/0605.ambition/trigger/vfx/.mcfunction
@@ -18,7 +18,7 @@
 # debug
     # scoreboard players set $Per Temporary 100
 
-# 割合に比例して$Countを設定
+# 割合に応じて$Countを設定
     execute if score $Per Temporary matches 50..99 run scoreboard players set $Count Temporary 1
     execute if score $Per Temporary matches 100 run scoreboard players set $Count Temporary 2
 


### PR DESCRIPTION
演出処理での、ダメージと最大ダメージの割合計算において、割合が100を突破してしまうとフルパワー演出が見れないという問題があった