### PR TITLE
💬 Mob の DamageAPI でのコメントミスの修正

### DIFF
--- a/Asset/data/asset/functions/mob/0138.combat_turret/tick/2.4.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0138.combat_turret/tick/2.4.damage.mcfunction
@@ -7,17 +7,12 @@
 # 演出
     particle minecraft:large_smoke ~ ~ ~ 0 0 0 0.4 10
 
-# ダメージ設定
-    # 与えるダメージ
-        data modify storage api: Argument.Damage set value 9.7f
-    # 魔法属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 雷属性
-        data modify storage api: Argument.ElementType set value "Thunder"
-    # ダメージ
-        function api:damage/modifier
-        execute as @p[gamemode=!creative,tag=LandingTarget,distance=..30] at @s run function api:damage/
-# リセット
+# ダメージ
+    data modify storage api: Argument.Damage set value 9.7f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "Thunder"
+    function api:damage/modifier
+    execute as @p[gamemode=!creative,tag=LandingTarget,distance=..30] at @s run function api:damage/
     function api:damage/reset
 
 # 着弾タグを消す

--- a/Asset/data/asset/functions/mob/0262.frestchika/tick/1.thunder/3.thunder_summon.mcfunction
+++ b/Asset/data/asset/functions/mob/0262.frestchika/tick/1.thunder/3.thunder_summon.mcfunction
@@ -15,17 +15,12 @@
     playsound entity.lightning_bolt.thunder hostile @a ~ ~ ~ 0.7 2
     playsound entity.lightning_bolt.impact hostile @a ~ ~ ~ 0.7 0
 
-# ダメージ設定
-    # 与えるダメージ
-        data modify storage api: Argument.Damage set value 50f
-    # 魔法属性
-        data modify storage api: Argument.AttackType set value "Magic"
-    # 雷属性
-        data modify storage api: Argument.ElementType set value "Thunder"
-    # ダメージ
-        function api:damage/modifier
-        execute as @a[tag=!PlayerShouldInvulnerable,distance=..3] at @s run function api:damage/
-# リセット
+# ダメージ
+    data modify storage api: Argument.Damage set value 50f
+    data modify storage api: Argument.AttackType set value "Magic"
+    data modify storage api: Argument.ElementType set value "Thunder"
+    function api:damage/modifier
+    execute as @a[tag=!PlayerShouldInvulnerable,distance=..3] at @s run function api:damage/
     function api:damage/reset
 
 

--- a/Asset/data/asset/functions/mob/0262.frestchika/tick/2.melee/4.slash.mcfunction
+++ b/Asset/data/asset/functions/mob/0262.frestchika/tick/2.melee/4.slash.mcfunction
@@ -5,16 +5,11 @@
 # @within function asset:mob/0262.frestchika/tick/2.melee/1.melee
 
 # ダメージ設定
-    # 与えるダメージ
-        data modify storage api: Argument.Damage set value 35.0f
-    # 魔法属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 無属性
-        data modify storage api: Argument.ElementType set value "Thunder"
-    # ダメージ
-        function api:damage/modifier
-        execute as @a[tag=!PlayerShouldInvulnerable,distance=..1] at @s run function api:damage/
-# リセット
+    data modify storage api: Argument.Damage set value 35.0f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "Thunder"
+    function api:damage/modifier
+    execute as @a[tag=!PlayerShouldInvulnerable,distance=..1] at @s run function api:damage/
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0262.frestchika/tick/3.melee2/3.thunder.mcfunction
+++ b/Asset/data/asset/functions/mob/0262.frestchika/tick/3.melee2/3.thunder.mcfunction
@@ -15,15 +15,10 @@
     playsound entity.lightning_bolt.thunder hostile @a ~ ~ ~ 0.7 2
     playsound entity.lightning_bolt.impact hostile @a ~ ~ ~ 0.7 0
 
-# ダメージ設定
-    # 与えるダメージ
-        data modify storage api: Argument.Damage set value 32f
-    # 魔法属性
-        data modify storage api: Argument.AttackType set value "Magic"
-    # 雷属性
-        data modify storage api: Argument.ElementType set value "Thunder"
-    # ダメージ
-        function api:damage/modifier
-        execute as @a[tag=!PlayerShouldInvulnerable,distance=..2] at @s run function api:damage/
-# リセット
+# ダメージ
+    data modify storage api: Argument.Damage set value 32f
+    data modify storage api: Argument.AttackType set value "Magic"
+    data modify storage api: Argument.ElementType set value "Thunder"
+    function api:damage/modifier
+    execute as @a[tag=!PlayerShouldInvulnerable,distance=..2] at @s run function api:damage/
     function api:damage/reset

--- a/Asset/data/asset/functions/mob/0262.frestchika/tick/3.melee2/4.slash.mcfunction
+++ b/Asset/data/asset/functions/mob/0262.frestchika/tick/3.melee2/4.slash.mcfunction
@@ -4,17 +4,12 @@
 #
 # @within function asset:mob/0262.frestchika/tick/3.melee2/1.melee2
 
-# ダメージ設定
-    # 与えるダメージ
-        data modify storage api: Argument.Damage set value 50.0f
-    # 魔法属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 無属性
-        data modify storage api: Argument.ElementType set value "Thunder"
-    # ダメージ
-        function api:damage/modifier
-        execute as @a[tag=!PlayerShouldInvulnerable,distance=..1] at @s run function api:damage/
-# リセット
+# ダメージ
+    data modify storage api: Argument.Damage set value 50.0f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "Thunder"
+    function api:damage/modifier
+    execute as @a[tag=!PlayerShouldInvulnerable,distance=..1] at @s run function api:damage/
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/app/attack/1.shot.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/app/attack/1.shot.mcfunction
@@ -21,17 +21,11 @@
     scoreboard players add @s 9F.BulletCount.Hg 1
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 35f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 35f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9F.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 終了

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/app/attack/1.shot_from_warp.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/app/attack/1.shot_from_warp.mcfunction
@@ -20,17 +20,11 @@
     scoreboard players add @s 9F.BulletCount.Hg 1
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 36f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 36f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9F.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 終了

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/app/attack/1.shot_weak.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/app/attack/1.shot_weak.mcfunction
@@ -21,17 +21,11 @@
     scoreboard players add @s 9F.BulletCount.Hg 1
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 28f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 28f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9F.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 終了

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/05_1_hg_spinkick/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/05_1_hg_spinkick/5.damage.mcfunction
@@ -9,17 +9,11 @@
     tag @a[tag=!PlayerShouldInvulnerable,distance=..2.8] add 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 45f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 45f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9F.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/05_2_hg_kickcombo/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/05_2_hg_kickcombo/5.damage.mcfunction
@@ -9,17 +9,11 @@
     tag @a[tag=!PlayerShouldInvulnerable,distance=..2] add 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 38f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 38f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9F.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/05_hg_riderkick/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/05_hg_riderkick/5.damage.mcfunction
@@ -9,17 +9,11 @@
     tag @a[tag=!PlayerShouldInvulnerable,distance=..2] add 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 42f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 42f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9F.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 与ダメージクールダウン設定

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/06_1_hg_lowkick/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/06_1_hg_lowkick/5.damage.mcfunction
@@ -10,17 +10,11 @@
     execute as @a[tag=9F.Temp.Target.Attack] at @s if block ~ ~-1 ~ #lib:no_collision run tag @s remove 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 10f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 10f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9F.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/06_hg_punch/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/06_hg_punch/5.damage.mcfunction
@@ -9,17 +9,11 @@
     tag @a[tag=!PlayerShouldInvulnerable,distance=..2] add 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 55f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 55f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9F.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/07_2_hg_heeloff/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/07_2_hg_heeloff/5.damage.mcfunction
@@ -10,17 +10,11 @@
     execute positioned ^ ^ ^2.5 run tag @a[tag=!PlayerShouldInvulnerable,distance=..1.4] add 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 50f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 50f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9F.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/07_3_hg_heelspin/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/07_3_hg_heelspin/5.damage.mcfunction
@@ -9,17 +9,11 @@
     tag @a[tag=!PlayerShouldInvulnerable,distance=..2.8] add 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 40f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 40f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9F.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/41_cover/5.1.damage_rider.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/41_cover/5.1.damage_rider.mcfunction
@@ -9,17 +9,11 @@
     tag @a[distance=..2] add 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 42f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 42f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9F.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 与ダメージクールダウン設定

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/41_cover/5.2.damage_spin.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/41_cover/5.2.damage_spin.mcfunction
@@ -9,17 +9,11 @@
     tag @a[distance=..2.8] add 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 45f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 45f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9F.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/41_cover/5.3.damage_low.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/41_cover/5.3.damage_low.mcfunction
@@ -10,17 +10,11 @@
     execute as @a[tag=9F.Temp.Target.Attack] at @s if block ~ ~-1 ~ #lib:no_collision run tag @s remove 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 52f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 52f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9F.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_1_kt_moveslash/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_1_kt_moveslash/5.damage.mcfunction
@@ -10,17 +10,11 @@
     execute positioned ^ ^ ^1.5 run tag @a[tag=!PlayerShouldInvulnerable,distance=..2] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 42f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 42f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_2_kt_movetospear/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_2_kt_movetospear/5.damage.mcfunction
@@ -12,17 +12,11 @@
     tag @a[tag=9G.Temp.Target.JumpAvoid] remove 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 50f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 50f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_4_kt_vacuslash/5.1.damage_slash.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_4_kt_vacuslash/5.1.damage_slash.mcfunction
@@ -14,17 +14,11 @@
     execute positioned ^ ^ ^10 run tag @a[tag=!PlayerShouldInvulnerable,distance=..3] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 55f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 55f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_4_kt_vacuslash/5.2.damage_impact.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_4_kt_vacuslash/5.2.damage_impact.mcfunction
@@ -11,17 +11,11 @@
     execute positioned ^ ^ ^3 run tag @a[tag=!PlayerShouldInvulnerable,distance=..2] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 70f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 70f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/04_1_kt_doubleslash/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/04_1_kt_doubleslash/5.damage.mcfunction
@@ -9,17 +9,11 @@
     tag @a[tag=!PlayerShouldInvulnerable,distance=..2.3] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 36f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 36f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/05_1_kt_setwarp/5.1.damage_slash.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/05_1_kt_setwarp/5.1.damage_slash.mcfunction
@@ -9,17 +9,11 @@
     execute positioned ^ ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..3] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 38f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 38f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/05_1_kt_setwarp/5.3.damage_spear.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/05_1_kt_setwarp/5.3.damage_spear.mcfunction
@@ -12,17 +12,11 @@
     tag @a[tag=9G.Temp.Target.JumpAvoid] remove 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 20
-        data modify storage api: Argument.Damage set value 50f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 50f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/05_1_kt_setwarp/5.3.damage_spear.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/05_1_kt_setwarp/5.3.damage_spear.mcfunction
@@ -12,7 +12,7 @@
     tag @a[tag=9G.Temp.Target.JumpAvoid] remove 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
+    # 20
         data modify storage api: Argument.Damage set value 50f
     # 第一属性
         data modify storage api: Argument.AttackType set value "Physical"

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/06_3_kt_draw_jumonji/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/06_3_kt_draw_jumonji/5.damage.mcfunction
@@ -9,17 +9,11 @@
     execute positioned ^ ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..3] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 45f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 45f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/06_5_kt_sheathe_counter/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/06_5_kt_sheathe_counter/5.damage.mcfunction
@@ -9,17 +9,11 @@
     tag @a[tag=!PlayerShouldInvulnerable,distance=..1.2] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 45f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 45f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_1_kt_jumpslash/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_1_kt_jumpslash/5.damage.mcfunction
@@ -9,17 +9,11 @@
     execute positioned ^ ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..2] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 40f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 40f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_2_kt_horizon/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_2_kt_horizon/5.damage.mcfunction
@@ -11,17 +11,11 @@
     execute positioned ^2 ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..2] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 40f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 40f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_3_kt_horizon_double/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_3_kt_horizon_double/5.damage.mcfunction
@@ -9,17 +9,11 @@
     execute positioned ^ ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..3] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 40f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 40f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_4_kt_dashattack/5.1.damage_spin.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_4_kt_dashattack/5.1.damage_spin.mcfunction
@@ -11,17 +11,11 @@
     execute positioned ^ ^ ^1.5 run tag @a[tag=!PlayerShouldInvulnerable,distance=..2.5] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 30f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 30f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_4_kt_dashattack/5.2.damage_cross.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_4_kt_dashattack/5.2.damage_cross.mcfunction
@@ -9,17 +9,11 @@
     execute positioned ^ ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..3] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 55f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 55f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/08_2_kt_throw/5.1.damage_catch.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/08_2_kt_throw/5.1.damage_catch.mcfunction
@@ -9,17 +9,11 @@
     tag @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 5f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 5f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/08_2_kt_throw/5.2.damage_throw.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/08_2_kt_throw/5.2.damage_throw.mcfunction
@@ -9,17 +9,11 @@
     tag @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 5f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 5f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/08_2_kt_throw/5.4.damage_pursuit.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/08_2_kt_throw/5.4.damage_pursuit.mcfunction
@@ -9,17 +9,11 @@
     execute positioned ^ ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..3] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 55f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 55f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/13_sc_warp/5.1.damage_slash.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/13_sc_warp/5.1.damage_slash.mcfunction
@@ -9,17 +9,11 @@
     execute positioned ^ ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..3] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 38f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 38f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/31_2_sync_crossfire_upper/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/31_2_sync_crossfire_upper/5.damage.mcfunction
@@ -10,17 +10,11 @@
     execute positioned ^ ^ ^1.6 run tag @a[tag=!PlayerShouldInvulnerable,distance=..2] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 45f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 45f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/32_1_sync_throw/5.1.damage_slash.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/32_1_sync_throw/5.1.damage_slash.mcfunction
@@ -20,9 +20,9 @@
     execute positioned ^ ^ ^ run tag @a[distance=..8.5] add 9G.Temp.Target.Attack.Sub
 
 # TODO:ダメージ
-        data modify storage api: Argument.Damage set value 50f
-        data modify storage api: Argument.AttackType set value "Physical"
-        data modify storage api: Argument.ElementType set value "None"
+    data modify storage api: Argument.Damage set value 50f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
     execute as @a[tag=9G.Temp.Target.Attack.Sub,tag=!9G.Temp.Target.Attack] at @s run function api:damage/
     function api:damage/reset

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/32_1_sync_throw/5.1.damage_slash.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/32_1_sync_throw/5.1.damage_slash.mcfunction
@@ -7,34 +7,24 @@
 
 # ヒット判定
     execute positioned ^ ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..5] add 9G.Temp.Target.Attack
+
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 62f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 62f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # ヒット判定
     execute positioned ^ ^ ^ run tag @a[distance=..8.5] add 9G.Temp.Target.Attack.Sub
+
 # TODO:ダメージ
-    # 与えるダメージ = 20
         data modify storage api: Argument.Damage set value 50f
-    # 第一属性
         data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
         data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack.Sub,tag=!9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # かちあげ

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/32_1_sync_throw/5.2.damage_burst.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/32_1_sync_throw/5.2.damage_burst.mcfunction
@@ -13,17 +13,11 @@
     execute positioned ^ ^1 ^ rotated ~240 ~ run function asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/32_1_sync_throw/6.5.particle_line_burst
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 55f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 55f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/41_cover/5.1.damage_jump.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/41_cover/5.1.damage_jump.mcfunction
@@ -9,17 +9,11 @@
     execute positioned ^ ^ ^ run tag @a[distance=..2] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 40f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 40f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/41_cover/5.2.damage_horizon.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/41_cover/5.2.damage_horizon.mcfunction
@@ -9,17 +9,11 @@
     execute positioned ^ ^ ^ run tag @a[distance=..3] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 40f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 40f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/41_cover/5.3.damage_cross.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/41_cover/5.3.damage_cross.mcfunction
@@ -9,17 +9,11 @@
     execute positioned ^ ^ ^ run tag @a[distance=..3] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    # 与えるダメージ = 20
-        data modify storage api: Argument.Damage set value 52f
-    # 第一属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 第二属性
-        data modify storage api: Argument.ElementType set value "None"
-# 補正functionを実行
+    data modify storage api: Argument.Damage set value 52f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# 対象に
     execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:damage/
-# リセット
     function api:damage/reset
 
 # 演出

--- a/Asset/data/asset/functions/mob/0377.grey_guardian_v2/tick/03.axe1/spin_damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0377.grey_guardian_v2/tick/03.axe1/spin_damage.mcfunction
@@ -10,15 +10,10 @@
     function asset:mob/0377.grey_guardian_v2/tick/03.axe1/particle
 
 
-# ダメージ設定
-    # 与えるダメージ
-        data modify storage api: Argument.Damage set value 15.0f
-    # 魔法属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 無属性
-        data modify storage api: Argument.ElementType set value "None"
-    # ダメージ
-        function api:damage/modifier
-        execute as @e[type=#lib:living,tag=Friend,tag=!Uninterferable,tag=!PlayerShouldInvulnerable,distance=..6] at @s run function api:damage/
-# リセット
+# ダメージ
+    data modify storage api: Argument.Damage set value 15.0f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
+    function api:damage/modifier
+    execute as @e[type=#lib:living,tag=Friend,tag=!Uninterferable,tag=!PlayerShouldInvulnerable,distance=..6] at @s run function api:damage/
     function api:damage/reset

--- a/Asset/data/asset/functions/mob/0377.grey_guardian_v2/tick/04.axe2/damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0377.grey_guardian_v2/tick/04.axe2/damage.mcfunction
@@ -4,15 +4,10 @@
 #
 # @within function asset:mob/0377.grey_guardian_v2/tick/04.axe2/main
 
-# 与えるダメージ
-    data modify storage api: Argument.Damage set value 49.0f
-# 魔法属性
-    data modify storage api: Argument.AttackType set value "Physical"
-# 無属性
-    data modify storage api: Argument.ElementType set value "None"
 # ダメージ
+    data modify storage api: Argument.Damage set value 49.0f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
-# プレイヤー用のダメージファンクション
     execute as @a[distance=..30] at @s run function asset:mob/0377.grey_guardian_v2/tick/04.axe2/damage_on_ground
-# リセット
     function api:damage/reset

--- a/Asset/data/asset/functions/mob/0378.red_knight_v3/tick/01.skill_slash/slash_wave.mcfunction
+++ b/Asset/data/asset/functions/mob/0378.red_knight_v3/tick/01.skill_slash/slash_wave.mcfunction
@@ -7,16 +7,10 @@
 # パーティクル
     function asset:mob/0378.red_knight_v3/tick/01.skill_slash/particle
 
-# 判定
-    # ダメージ設定
-    # 与えるダメージ
-        data modify storage api: Argument.Damage set value 20.0f
-    # 物理属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 無属性
-        data modify storage api: Argument.ElementType set value "None"
-    # ダメージ
-        function api:damage/modifier
-        execute as @a[tag=!PlayerShouldInvulnerable,distance=..3] run function api:damage/
-# リセット
+# ダメージ
+    data modify storage api: Argument.Damage set value 20.0f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "None"
+    function api:damage/modifier
+    execute as @a[tag=!PlayerShouldInvulnerable,distance=..3] run function api:damage/
     function api:damage/reset

--- a/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/thunder/aiming_laser/laser/hit.mcfunction
+++ b/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/thunder/aiming_laser/laser/hit.mcfunction
@@ -9,15 +9,10 @@
     particle minecraft:large_smoke ~ ~ ~ 0 0 0 0.4 20
     playsound minecraft:entity.generic.explode neutral @a ~ ~ ~ 1 1.5
 
-# ダメージ設定
-    # 与えるダメージ
-        data modify storage api: Argument.Damage set value 15.0f
-    # 魔法属性
-        data modify storage api: Argument.AttackType set value "Magic"
-    # 雷属性
-        data modify storage api: Argument.ElementType set value "Thunder"
-    # ダメージ
-        function api:damage/modifier
-        execute positioned ~-0.5 ~-0.5 ~-0.5 as @a[tag=!PlayerShouldInvulnerable,dx=0] run function api:damage/
-# リセット
+# ダメージ
+    data modify storage api: Argument.Damage set value 15.0f
+    data modify storage api: Argument.AttackType set value "Magic"
+    data modify storage api: Argument.ElementType set value "Thunder"
+    function api:damage/modifier
+    execute positioned ~-0.5 ~-0.5 ~-0.5 as @a[tag=!PlayerShouldInvulnerable,dx=0] run function api:damage/
     function api:damage/reset

--- a/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/thunder/lightning_stab/chain_lightning/strong/damage.mcfunction
+++ b/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/thunder/lightning_stab/chain_lightning/strong/damage.mcfunction
@@ -4,16 +4,10 @@
 #
 # @within function asset:mob/1004.tultaria/tick/skill/thunder/lightning_stab/chain_lightning/strong/thunder.recursive
 
-# ダメージ設定
-    # 与えるダメージ
-        data modify storage api: Argument.Damage set value 40.0f
-    # 魔法属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 雷属性
-        data modify storage api: Argument.ElementType set value "Thunder"
-    # ダメージ補正
-        function api:damage/modifier
-    # ダメージ与える
-        execute as @a[tag=!PlayerShouldInvulnerable,dx=0] run function api:damage/
-# リセット
+# ダメージ
+    data modify storage api: Argument.Damage set value 40.0f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "Thunder"
+    function api:damage/modifier
+    execute as @a[tag=!PlayerShouldInvulnerable,dx=0] run function api:damage/
     function api:damage/reset

--- a/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/thunder/lightning_stab/chain_lightning/weak/damage.mcfunction
+++ b/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/thunder/lightning_stab/chain_lightning/weak/damage.mcfunction
@@ -4,16 +4,10 @@
 #
 # @within function asset:mob/1004.tultaria/tick/skill/thunder/lightning_stab/chain_lightning/weak/thunder.recusrive
 
-# ダメージ設定
-    # 与えるダメージ
-        data modify storage api: Argument.Damage set value 10.0f
-    # 魔法属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 雷属性
-        data modify storage api: Argument.ElementType set value "Thunder"
-    # ダメージ補正
-        function api:damage/modifier
-    # ダメージ与える
-        execute as @a[tag=!PlayerShouldInvulnerable,dx=0] run function api:damage/
-# リセット
+# ダメージ
+    data modify storage api: Argument.Damage set value 10.0f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "Thunder"
+    function api:damage/modifier
+    execute as @a[tag=!PlayerShouldInvulnerable,dx=0] run function api:damage/
     function api:damage/reset

--- a/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/thunder/lightning_stab/hyper_stab/damage.mcfunction
+++ b/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/thunder/lightning_stab/hyper_stab/damage.mcfunction
@@ -4,16 +4,10 @@
 #
 # @within function asset:mob/1004.tultaria/tick/skill/thunder/lightning_stab/hyper_stab/recursive
 
-# ダメージ設定
-    # 与えるダメージ
-        data modify storage api: Argument.Damage set value 50.0f
-    # 魔法属性
-        data modify storage api: Argument.AttackType set value "Physical"
-    # 雷属性
-        data modify storage api: Argument.ElementType set value "Thunder"
-    # ダメージ補正
-        function api:damage/modifier
-    # ダメージ与える
-        execute as @a[tag=!PlayerShouldInvulnerable,dx=0] run function api:damage/
-# リセット
+# ダメージ
+    data modify storage api: Argument.Damage set value 50.0f
+    data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.ElementType set value "Thunder"
+    function api:damage/modifier
+    execute as @a[tag=!PlayerShouldInvulnerable,dx=0] run function api:damage/
     function api:damage/reset

--- a/Asset/data/asset/functions/mob/1005.illusion_of_loyalty/tick/moveset/skill/thunder/aiming_laser/laser/hit.mcfunction
+++ b/Asset/data/asset/functions/mob/1005.illusion_of_loyalty/tick/moveset/skill/thunder/aiming_laser/laser/hit.mcfunction
@@ -9,15 +9,10 @@
     particle minecraft:large_smoke ~ ~ ~ 0 0 0 0.4 20
     playsound minecraft:entity.generic.explode neutral @a ~ ~ ~ 1 1.5
 
-# ダメージ設定
-    # 与えるダメージ
-        data modify storage api: Argument.Damage set value 30.0f
-    # 魔法属性
-        data modify storage api: Argument.AttackType set value "Magic"
-    # 雷属性
-        data modify storage api: Argument.ElementType set value "Thunder"
-    # ダメージ
-        function api:damage/modifier
-        execute positioned ~-0.5 ~-0.5 ~-0.5 as @a[tag=!PlayerShouldInvulnerable,dx=0] run function api:damage/
-# リセット
+# ダメージ
+    data modify storage api: Argument.Damage set value 30.0f
+    data modify storage api: Argument.AttackType set value "Magic"
+    data modify storage api: Argument.ElementType set value "Thunder"
+    function api:damage/modifier
+    execute positioned ~-0.5 ~-0.5 ~-0.5 as @a[tag=!PlayerShouldInvulnerable,dx=0] run function api:damage/
     function api:damage/reset


### PR DESCRIPTION
実際の属性/ダメージと違うものだったり、それの発生要因となるものを消し飛ばした
本当は全てのDamageAPIで最小限にしたかったけど、現実的に無理なのでやめた