### PR TITLE
⚖️ [Mob 89-90] 断切者の攻撃に被回復量低下の効果を追加

### DIFF
--- a/Asset/data/asset/functions/effect/0014.receive_heal_debuff/_/end.mcfunction
+++ b/Asset/data/asset/functions/effect/0014.receive_heal_debuff/_/end.mcfunction
@@ -1,0 +1,7 @@
+#> asset:effect/0014.receive_heal_debuff/_/end
+#
+# Effectの効果の終了時に実行されるfunction
+#
+# @within tag/function asset:effect/end
+
+execute if data storage asset:context {id:14} run function asset:effect/0014.receive_heal_debuff/end/

--- a/Asset/data/asset/functions/effect/0014.receive_heal_debuff/_/given.mcfunction
+++ b/Asset/data/asset/functions/effect/0014.receive_heal_debuff/_/given.mcfunction
@@ -1,0 +1,7 @@
+#> asset:effect/0014.receive_heal_debuff/_/given
+#
+# Effectが付与された時に実行されるfunction
+#
+# @within tag/function asset:effect/given
+
+execute if data storage asset:context {id:14} run function asset:effect/0014.receive_heal_debuff/given/

--- a/Asset/data/asset/functions/effect/0014.receive_heal_debuff/_/re-given.mcfunction
+++ b/Asset/data/asset/functions/effect/0014.receive_heal_debuff/_/re-given.mcfunction
@@ -1,0 +1,7 @@
+#> asset:effect/0014.receive_heal_debuff/_/re-given
+#
+# Effectが上書きされた時に実行されるfunction
+#
+# @within tag/function asset:effect/re-given
+
+execute if data storage asset:context {id:14} run function asset:effect/0014.receive_heal_debuff/re-given/

--- a/Asset/data/asset/functions/effect/0014.receive_heal_debuff/_/register.mcfunction
+++ b/Asset/data/asset/functions/effect/0014.receive_heal_debuff/_/register.mcfunction
@@ -1,0 +1,7 @@
+#> asset:effect/0014.receive_heal_debuff/_/register
+#
+#
+#
+# @within tag/function asset:effect/register
+
+execute if data storage asset:context {id:14} run function asset:effect/0014.receive_heal_debuff/register

--- a/Asset/data/asset/functions/effect/0014.receive_heal_debuff/_/remove.mcfunction
+++ b/Asset/data/asset/functions/effect/0014.receive_heal_debuff/_/remove.mcfunction
@@ -1,0 +1,7 @@
+#> asset:effect/0014.receive_heal_debuff/_/remove
+#
+# Effectが神器や牛乳によって削除された時に実行されるfunction
+#
+# @within tag/function asset:effect/remove
+
+execute if data storage asset:context {id:14} run function asset:effect/0014.receive_heal_debuff/remove/

--- a/Asset/data/asset/functions/effect/0014.receive_heal_debuff/end/.mcfunction
+++ b/Asset/data/asset/functions/effect/0014.receive_heal_debuff/end/.mcfunction
@@ -1,0 +1,8 @@
+#> asset:effect/0014.receive_heal_debuff/end/
+#
+# Effectの効果が切れた時の処理
+#
+# @within function asset:effect/0014.receive_heal_debuff/_/end
+
+# 補正を削除する
+    function asset:effect/0014.receive_heal_debuff/modifier/remove

--- a/Asset/data/asset/functions/effect/0014.receive_heal_debuff/given/.mcfunction
+++ b/Asset/data/asset/functions/effect/0014.receive_heal_debuff/given/.mcfunction
@@ -1,0 +1,8 @@
+#> asset:effect/0014.receive_heal_debuff/given/
+#
+# Effectが付与された時の処理
+#
+# @within function asset:effect/0014.receive_heal_debuff/_/given
+
+# 補正を付与する
+    function asset:effect/0014.receive_heal_debuff/modifier/add

--- a/Asset/data/asset/functions/effect/0014.receive_heal_debuff/modifier/add.mcfunction
+++ b/Asset/data/asset/functions/effect/0014.receive_heal_debuff/modifier/add.mcfunction
@@ -1,0 +1,14 @@
+#> asset:effect/0014.receive_heal_debuff/modifier/add
+#
+# 補正を付与する
+#
+# @within function
+#   asset:effect/0014.receive_heal_debuff/given/
+#   asset:effect/0014.receive_heal_debuff/re-given/
+
+# 補正を付与する
+    data modify storage api: Argument.UUID set value [I;1,3,-1,0]
+    data modify storage api: Argument.UUID[2] set from storage asset:context id
+    execute store result storage api: Argument.Amount double -0.05 run data get storage asset:context Stack 1
+    data modify storage api: Argument.Operation set value "multiply"
+    function api:modifier/receive_heal/add

--- a/Asset/data/asset/functions/effect/0014.receive_heal_debuff/modifier/remove.mcfunction
+++ b/Asset/data/asset/functions/effect/0014.receive_heal_debuff/modifier/remove.mcfunction
@@ -1,0 +1,13 @@
+#> asset:effect/0014.receive_heal_debuff/modifier/remove
+#
+# 補正を削除する
+#
+# @within function
+#   asset:effect/0014.receive_heal_debuff/end/
+#   asset:effect/0014.receive_heal_debuff/re-given/
+#   asset:effect/0014.receive_heal_debuff/remove/
+
+# 補正を削除する
+    data modify storage api: Argument.UUID set value [I;1,3,-1,0]
+    data modify storage api: Argument.UUID[2] set from storage asset:context id
+    function api:modifier/receive_heal/remove

--- a/Asset/data/asset/functions/effect/0014.receive_heal_debuff/re-given/.mcfunction
+++ b/Asset/data/asset/functions/effect/0014.receive_heal_debuff/re-given/.mcfunction
@@ -1,0 +1,9 @@
+#> asset:effect/0014.receive_heal_debuff/re-given/
+#
+# Effectが上書きされた時の処理
+#
+# @within function asset:effect/0014.receive_heal_debuff/_/re-given
+
+# 補正を削除し付与する
+    function asset:effect/0014.receive_heal_debuff/modifier/remove
+    function asset:effect/0014.receive_heal_debuff/modifier/add

--- a/Asset/data/asset/functions/effect/0014.receive_heal_debuff/register.mcfunction
+++ b/Asset/data/asset/functions/effect/0014.receive_heal_debuff/register.mcfunction
@@ -1,0 +1,39 @@
+#> asset:effect/0014.receive_heal_debuff/register
+#
+# Effectのデータを指定
+#
+# @within function asset:effect/0014.receive_heal_debuff/_/register
+
+# ExtendsSafe (boolean) (default = false)
+    data modify storage asset:effect ExtendsSafe set value true
+# ID (int)
+    data modify storage asset:effect ID set value 14
+# 名前 (TextComponentString)
+    data modify storage asset:effect Name set value '{"text":"被回復量低下"}'
+# 説明文 (TextComponentString[])
+    data modify storage asset:effect Description set value ['{"text":"被回復量が低下する"}']
+# 効果時間 (int) (default = API || error)
+    # data modify storage asset:effect Duration set value
+# スタック (int) (default = API || 1)
+    # data modify storage asset:effect Stack set value
+# 効果時間の操作方法 (default = API || "replace")
+    # data modify storage asset:effect DurationOperation set value
+# スタックの操作方法 (default = API || "replace")
+    # data modify storage asset:effect StackOperation set value
+# 最大効果時間 (int) (default = 2147483647)
+    # data modify storage asset:effect MaxDuration set value
+# 最大スタック (int) (default = 2147483647)
+    data modify storage asset:effect MaxStack set value 100
+# 悪い効果か否か (boolean)
+    data modify storage asset:effect IsBadEffect set value true
+# 死亡時のエフェクトの処理 (default = "remove")
+    # data modify storage asset:effect ProcessOnDied set value
+# 消すのに必要なレベル (int) (default = 1)
+    data modify storage asset:effect RequireClearLv set value 1
+# エフェクトをUIに表示するか (boolean) (default = true)
+    # data modify storage asset:effect Visible set value
+# エフェクトのスタックををUIに表示するか (boolean) (default = true)
+    # data modify storage asset:effect StackVisible set value
+
+# フィールド
+    # data modify storage asset:effect Field set value {}

--- a/Asset/data/asset/functions/effect/0014.receive_heal_debuff/remove/.mcfunction
+++ b/Asset/data/asset/functions/effect/0014.receive_heal_debuff/remove/.mcfunction
@@ -1,0 +1,8 @@
+#> asset:effect/0014.receive_heal_debuff/remove/
+#
+# Effectが削除された時の処理
+#
+# @within function asset:effect/0014.receive_heal_debuff/_/remove
+
+# 補正を削除する
+    function asset:effect/0014.receive_heal_debuff/modifier/remove

--- a/Asset/data/asset/functions/effect/0064.receive_heal_debuff/_/register.mcfunction
+++ b/Asset/data/asset/functions/effect/0064.receive_heal_debuff/_/register.mcfunction
@@ -1,0 +1,7 @@
+#> asset:effect/0064.receive_heal_debuff/_/register
+#
+#
+#
+# @within tag/function asset:effect/register
+
+execute if data storage asset:context {id:64} run function asset:effect/0064.receive_heal_debuff/register

--- a/Asset/data/asset/functions/effect/0064.receive_heal_debuff/register.mcfunction
+++ b/Asset/data/asset/functions/effect/0064.receive_heal_debuff/register.mcfunction
@@ -1,0 +1,13 @@
+#> asset:effect/0064.receive_heal_debuff/register
+#
+# Effectのデータを指定
+#
+# @within function asset:effect/0064.receive_heal_debuff/_/register
+
+# 継承 (int)
+    data modify storage asset:effect Extends append value 14
+    function asset:effect/extends
+# ID (int)
+    data modify storage asset:effect ID set value 64
+# 消すのに必要なレベル (int) (default = 1)
+    data modify storage asset:effect RequireClearLv set value 2

--- a/Asset/data/asset/functions/effect/0114.receive_heal_debuff/_/register.mcfunction
+++ b/Asset/data/asset/functions/effect/0114.receive_heal_debuff/_/register.mcfunction
@@ -1,0 +1,7 @@
+#> asset:effect/0114.receive_heal_debuff/_/register
+#
+#
+#
+# @within tag/function asset:effect/register
+
+execute if data storage asset:context {id:114} run function asset:effect/0114.receive_heal_debuff/register

--- a/Asset/data/asset/functions/effect/0114.receive_heal_debuff/register.mcfunction
+++ b/Asset/data/asset/functions/effect/0114.receive_heal_debuff/register.mcfunction
@@ -1,0 +1,13 @@
+#> asset:effect/0114.receive_heal_debuff/register
+#
+# Effectのデータを指定
+#
+# @within function asset:effect/0114.receive_heal_debuff/_/register
+
+# 継承 (int)
+    data modify storage asset:effect Extends append value 14
+    function asset:effect/extends
+# ID (int)
+    data modify storage asset:effect ID set value 114
+# 消すのに必要なレベル (int) (default = 1)
+    data modify storage asset:effect RequireClearLv set value 3

--- a/Asset/data/asset/functions/mob/0089.decapitation/attack/.mcfunction
+++ b/Asset/data/asset/functions/mob/0089.decapitation/attack/.mcfunction
@@ -14,6 +14,14 @@
 # 何故かこうするとプレイヤーと同じ剣の降り方をする
     item replace entity @s weapon with stick{CustomModelData:20022}
 
+# 被回復低下
+    function api:global_vars/get_difficulty
+    data modify storage api: Argument.ID set value 14
+    execute store result storage api: Argument.Stack int 2 run data get storage api: Return.Difficulty
+    data modify storage api: Argument.Duration set value 200
+    execute as @p[tag=Victim] run function api:entity/mob/effect/give
+    function api:entity/mob/effect/reset
+
 # ダメージ
     data modify storage api: Argument.Damage set from storage asset:context this.Damage
     data modify storage api: Argument.AttackType set value "Physical"

--- a/Asset/data/asset/tags/functions/effect/end.json
+++ b/Asset/data/asset/tags/functions/effect/end.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "asset:effect/0014.receive_heal_debuff/_/end",
         "asset:effect/0294.dance_with_hardluck/_/end",
         "asset:effect/0293.beyond_the_speed/_/end",
         "asset:effect/0292.awaited_opportunity/_/end",

--- a/Asset/data/asset/tags/functions/effect/given.json
+++ b/Asset/data/asset/tags/functions/effect/given.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "asset:effect/0014.receive_heal_debuff/_/given",
         "asset:effect/0293.beyond_the_speed/_/given",
         "asset:effect/0292.awaited_opportunity/_/given",
         "asset:effect/0304.residue_of_pumpkin/_/given",

--- a/Asset/data/asset/tags/functions/effect/re-given.json
+++ b/Asset/data/asset/tags/functions/effect/re-given.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "asset:effect/0014.receive_heal_debuff/_/re-given",
         "asset:effect/0308.healer_trance/_/re-given",
         "asset:effect/0309.healer_trance/_/re-given",
         "asset:effect/0253.purifying_indigo/_/re-given",

--- a/Asset/data/asset/tags/functions/effect/register.json
+++ b/Asset/data/asset/tags/functions/effect/register.json
@@ -1,5 +1,8 @@
 {
     "values": [
+        "asset:effect/0114.receive_heal_debuff/_/register",
+        "asset:effect/0064.receive_heal_debuff/_/register",
+        "asset:effect/0014.receive_heal_debuff/_/register",
         "asset:effect/0294.dance_with_hardluck/_/register",
         "asset:effect/0293.beyond_the_speed/_/register",
         "asset:effect/0292.awaited_opportunity/_/register",

--- a/Asset/data/asset/tags/functions/effect/remove.json
+++ b/Asset/data/asset/tags/functions/effect/remove.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "asset:effect/0014.receive_heal_debuff/_/remove",
         "asset:effect/0294.dance_with_hardluck/_/remove",
         "asset:effect/0293.beyond_the_speed/_/remove",
         "asset:effect/0292.awaited_opportunity/_/remove",


### PR DESCRIPTION
Fix #670 