### PR TITLE
:wrench: MobAsset の登録処理のみを生成した時 ID が入力されない問題を修正

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1677,6 +1677,14 @@
                         "    function api:mob/summon"
                     ]
                 }
+            ],
+            "customQuestion": [
+                {
+                    "name": "id",
+                    "question": "MobのID",
+                    "pattern": "[1-9][0-9]*",
+                    "patternErrorMessage": "数値のみが許されるよ"
+                }
             ]
         },
         {


### PR DESCRIPTION
Fix #687 