### PR TITLE
🧑‍💻 SpreadMarkerのTagの定義漏れを一括で修正

### DIFF
--- a/Asset/data/asset/functions/artifact/0210.terra_blade/trigger/3.2.terra_shot_init.mcfunction
+++ b/Asset/data/asset/functions/artifact/0210.terra_blade/trigger/3.2.terra_shot_init.mcfunction
@@ -6,7 +6,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 # パーティクル
     particle minecraft:dust 0 1 0 1 ~ ~ ~ 0.1 0.1 0.1 0 2

--- a/Asset/data/asset/functions/artifact/0210.terra_blade/trigger/event/random_position.mcfunction
+++ b/Asset/data/asset/functions/artifact/0210.terra_blade/trigger/event/random_position.mcfunction
@@ -6,7 +6,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
     summon marker ~ ~ ~ {Tags:["SpreadMarker"]}
     data modify storage lib: Argument.Distance set value 0.5f

--- a/Asset/data/asset/functions/artifact/0373.ice_sorcery/trigger/3.2.beamshot2.mcfunction
+++ b/Asset/data/asset/functions/artifact/0373.ice_sorcery/trigger/3.2.beamshot2.mcfunction
@@ -8,7 +8,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 # 前方拡散事前準備
     summon marker ~ ~ ~ {Tags:["SpreadMarker"]}

--- a/Asset/data/asset/functions/artifact/0573.final_prism/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/0573.final_prism/trigger/3.main.mcfunction
@@ -6,7 +6,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 # 基本的な使用時の処理(MP消費や使用回数の処理など)を行う auto/feet/legs/chest/head/mainhand/offhandを記載してね
     function asset:artifact/common/use/mainhand

--- a/Asset/data/asset/functions/artifact/0607.u_and_w_06/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/0607.u_and_w_06/trigger/3.main.mcfunction
@@ -3,6 +3,7 @@
 # 神器のメイン処理部
 #
 # @within function asset:artifact/0607.u_and_w_06/trigger/2.check_condition
+
 #> Private
 # @private
     #declare score_holder $UseCount

--- a/Asset/data/asset/functions/artifact/0609.lunar_flare/trigger/projectile/summon_laser.mcfunction
+++ b/Asset/data/asset/functions/artifact/0609.lunar_flare/trigger/projectile/summon_laser.mcfunction
@@ -7,7 +7,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 # 前方拡散設定
     summon marker ~ ~ ~ {Tags:["SpreadMarker"]}

--- a/Asset/data/asset/functions/artifact/1024.brave_rod/trigger/combo/beam1.mcfunction
+++ b/Asset/data/asset/functions/artifact/1024.brave_rod/trigger/combo/beam1.mcfunction
@@ -6,7 +6,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 # 演出
     execute positioned ^ ^ ^1 run playsound ogg:block.respawn_anchor.deplete2 player @a ~ ~ ~ 1 1.5

--- a/Asset/data/asset/functions/artifact/1024.brave_rod/trigger/combo/beam3_burst.mcfunction
+++ b/Asset/data/asset/functions/artifact/1024.brave_rod/trigger/combo/beam3_burst.mcfunction
@@ -6,7 +6,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 # 演出
     execute positioned ^ ^ ^1 run playsound ogg:block.respawn_anchor.deplete1 player @a ~ ~ ~ 1 2
@@ -25,4 +25,3 @@
         execute at @e[type=marker,tag=SpreadMarker,limit=1] rotated as @s run function asset:artifact/1024.brave_rod/trigger/combo/beam3_shot
     # リセット
         kill @e[type=marker,tag=SpreadMarker]
-

--- a/Asset/data/asset/functions/mob/0053.executioners/attack/.mcfunction
+++ b/Asset/data/asset/functions/mob/0053.executioners/attack/.mcfunction
@@ -7,8 +7,8 @@
 # バニラの攻撃じゃなかったら return
     execute unless data storage asset:context Attack{IsVanilla:true} run return fail
 
-#> tag
-# @within function asset:mob/0053.executioners/attack/
+#> Private
+# @private
     #declare tag SpreadMarker
 
 # 演出

--- a/Asset/data/asset/functions/mob/0138.combat_turret/tick/2.2.ready.mcfunction
+++ b/Asset/data/asset/functions/mob/0138.combat_turret/tick/2.2.ready.mcfunction
@@ -3,6 +3,7 @@
 # 発砲準備をします
 #
 # @within function asset:mob/0138.combat_turret/tick/2.1.near_player
+
 #> tag
 # @private
     #declare tag SpreadMarker

--- a/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/base_move/passive_laser/summon.mcfunction
+++ b/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/base_move/passive_laser/summon.mcfunction
@@ -6,7 +6,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 # 拡散
     # ID指定

--- a/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/skill/firebomb/spread_ball.mcfunction
+++ b/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/skill/firebomb/spread_ball.mcfunction
@@ -6,7 +6,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 # 拡散させるEntityを召喚する
     execute anchored eyes positioned ^-0.4 ^-0.3 ^0.5 run summon marker ~ ~ ~ {Tags:["SpreadMarker"]}

--- a/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/skill/ground_slam/laser/.mcfunction
+++ b/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/skill/ground_slam/laser/.mcfunction
@@ -6,7 +6,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 # 拡散
     # ID指定

--- a/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/skill/ground_slam/spread/.mcfunction
+++ b/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/skill/ground_slam/spread/.mcfunction
@@ -6,7 +6,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 # 拡散
     # ID指定

--- a/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/skill/ground_slam/spread/recursive.mcfunction
+++ b/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/skill/ground_slam/spread/recursive.mcfunction
@@ -8,7 +8,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 # 拡散
     # ID指定

--- a/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/skill/rush_punch/punch/.mcfunction
+++ b/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/skill/rush_punch/punch/.mcfunction
@@ -6,7 +6,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 
 # ちょ～っとずつ進む、ただしプレイヤーを捕捉していない場合

--- a/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/skill/summon_minion/spread.mcfunction
+++ b/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/skill/summon_minion/spread.mcfunction
@@ -6,7 +6,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 # 拡散用marker召喚
     summon marker ~ ~ ~ {Tags:["SpreadMarker"]}

--- a/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/skill/triple_fireball/shoot/any.mcfunction
+++ b/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/skill/triple_fireball/shoot/any.mcfunction
@@ -8,7 +8,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 # 拡散弾
     # ID指定

--- a/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/skill/triple_fireball/shoot/triple.mcfunction
+++ b/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/skill/triple_fireball/shoot/triple.mcfunction
@@ -6,7 +6,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 # サウンド
     function asset:mob/0311.blazing_inferno/tick/skill/triple_fireball/shoot/vfx

--- a/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/laser/shoot/.mcfunction
+++ b/Asset/data/asset/functions/mob/0372.tutankhamen/tick/skill/laser/shoot/.mcfunction
@@ -6,7 +6,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 # 演出
     execute positioned ^ ^ ^1 run playsound ogg:block.respawn_anchor.deplete1 player @a ~ ~ ~ 1.5 2

--- a/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/water/homing_shot/shot/.mcfunction
+++ b/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/water/homing_shot/shot/.mcfunction
@@ -6,8 +6,8 @@
 
 #> 行き先マーカー
 # @private
-#declare tag FacingMarker
-#declare tag SpreadMarker
+    #declare tag FacingMarker
+    #declare tag SpreadMarker
 
 # 弾を出す
     # 中心

--- a/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/water/homing_shot/shot/summon.mcfunction
+++ b/Asset/data/asset/functions/mob/1004.tultaria/tick/skill/water/homing_shot/shot/summon.mcfunction
@@ -6,13 +6,13 @@
 
 #> 行き先マーカー
 # @private
-#declare tag FacingMarker
-#declare tag SpreadMarker
+    #declare tag FacingMarker
+    #declare tag SpreadMarker
 
 # 発射体のステータス設定
     data modify storage api: Argument.FieldOverride set value {Speed:1,Range:100,MovePerStep:0.1}
     execute store result storage api: Argument.FieldOverride.MobUUID int 1 run scoreboard players get @s MobUUID
-    
+
 # 召喚
     data modify storage api: Argument.ID set value 2044
     execute positioned ~ ~1.5 ~ run function api:object/summon

--- a/Asset/data/asset/functions/mob/1005.illusion_of_loyalty/tick/moveset/skill/water/homing_shot/shot/.mcfunction
+++ b/Asset/data/asset/functions/mob/1005.illusion_of_loyalty/tick/moveset/skill/water/homing_shot/shot/.mcfunction
@@ -6,7 +6,7 @@
 
 #> 行き先マーカー
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 # 拡散させて実行
     # 拡散させるEntityを召喚する

--- a/Asset/data/asset/functions/mob/1005.illusion_of_loyalty/tick/moveset/skill/water/homing_shot/shot/summon.mcfunction
+++ b/Asset/data/asset/functions/mob/1005.illusion_of_loyalty/tick/moveset/skill/water/homing_shot/shot/summon.mcfunction
@@ -6,7 +6,7 @@
 
 #> 行き先マーカー
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 # 発射体のステータス設定
     data modify storage api: Argument.FieldOverride set value {Speed:1,Range:100,MovePerStep:0.1}

--- a/Asset/data/asset/functions/object/1050.call_fulstuka/tick/1.skill_gun/3.ready.mcfunction
+++ b/Asset/data/asset/functions/object/1050.call_fulstuka/tick/1.skill_gun/3.ready.mcfunction
@@ -3,6 +3,7 @@
 # 発砲準備をします
 #
 # @within function asset:object/1050.call_fulstuka/tick/1.skill_gun/1.skill_gun
+
 #> tag
 # @private
     #declare tag SpreadMarker

--- a/Asset/data/asset/functions/object/1082.soulfire_burst_bigshot/range_over/summon_small_shot.mcfunction
+++ b/Asset/data/asset/functions/object/1082.soulfire_burst_bigshot/range_over/summon_small_shot.mcfunction
@@ -6,7 +6,7 @@
 
 #> SpreadLib
 # @private
-#declare tag SpreadMarker
+    #declare tag SpreadMarker
 
 
 # 拡散値


### PR DESCRIPTION
本当は全てのTagでやるべきなんだけど、開発しててSpreadMarkerが全体定義なのに耐えられなかった