### PR TITLE
⚖ [Mob 228] フロストアイLv4が付与する鈍足の解除Lvを1に修正

### DIFF
--- a/Asset/data/asset/functions/mob/0227.frost_eye/register.mcfunction
+++ b/Asset/data/asset/functions/mob/0227.frost_eye/register.mcfunction
@@ -67,4 +67,3 @@
 # フィールド
 # 与えるダメージ
     data modify storage asset:mob Field.Damage set value 8.0f
-    data modify storage asset:mob Field.EffectID set value 17

--- a/Asset/data/asset/functions/mob/0227.frost_eye/tick/debuff.mcfunction
+++ b/Asset/data/asset/functions/mob/0227.frost_eye/tick/debuff.mcfunction
@@ -9,7 +9,7 @@
 
 # (難易度値 * 2)のスタックだけ鈍足を付与する
 # フィールドで付与する鈍足を変えるようにする
-    data modify storage api: Argument.ID set from storage asset:context this.EffectID
+    data modify storage api: Argument.ID set value 17
     execute store result storage api: Argument.Stack int 2 run data get storage api: Return.Difficulty
     data modify storage api: Argument.Duration set value 80
     function api:entity/mob/effect/give

--- a/Asset/data/asset/functions/mob/0228.frost_eye/register.mcfunction
+++ b/Asset/data/asset/functions/mob/0228.frost_eye/register.mcfunction
@@ -18,4 +18,3 @@
 # フィールド
 # 与えるダメージ
     data modify storage asset:mob Field.Damage set value 35f
-    data modify storage asset:mob Field.EffectID set value 67


### PR DESCRIPTION
Fix #1097