### PR TITLE
⚖️ [Trader 2] 羊の加護を攻略進捗度で販売するように

### DIFF
--- a/Asset/data/asset/functions/artifact/0087.sheep_blessing/register.mcfunction
+++ b/Asset/data/asset/functions/artifact/0087.sheep_blessing/register.mcfunction
@@ -1,7 +1,0 @@
-#> asset:artifact/0087.sheep_blessing/register
-#
-# 神器プールへの登録処理
-#
-# @within tag/function asset:artifact/register
-
-data modify storage asset:artifact RarityRegistry[3] append value [87]

--- a/Asset/data/asset/functions/trader/2/register.mcfunction
+++ b/Asset/data/asset/functions/trader/2/register.mcfunction
@@ -64,3 +64,9 @@ execute unless loaded 19 15 -29 run return 1
     data modify storage asset:trader Trades append value {}
     data modify storage asset:trader Trades[-1].BuyA set value {PresetItem:"currency/high",Count:2b}
     data modify storage asset:trader Trades[-1].Sell set value 1142
+
+# 取引 羊の加護
+    data modify storage asset:trader Trades append value {}
+    data modify storage asset:trader Trades[-1].BuyA set value {PresetItem:"currency/high",Count:6b}
+    data modify storage asset:trader Trades[-1].Sell set value 87
+    data modify storage asset:trader Trades[-1].RequiredProgress set value 16

--- a/Asset/data/asset/functions/trader/2/register.mcfunction
+++ b/Asset/data/asset/functions/trader/2/register.mcfunction
@@ -69,4 +69,4 @@ execute unless loaded 19 15 -29 run return 1
     data modify storage asset:trader Trades append value {}
     data modify storage asset:trader Trades[-1].BuyA set value {PresetItem:"currency/high",Count:6b}
     data modify storage asset:trader Trades[-1].Sell set value 87
-    data modify storage asset:trader Trades[-1].RequiredProgress set value 16
+    data modify storage asset:trader Trades[-1].RequiredProgress set value 50

--- a/Asset/data/asset/tags/functions/artifact/register.json
+++ b/Asset/data/asset/tags/functions/artifact/register.json
@@ -156,7 +156,6 @@
         "asset:artifact/0077.swords_of_waterfall_climbing/register",
         "asset:artifact/0078.self_destruct_order/register",
         "asset:artifact/0079.shoot_down_a_flying_dragon/register",
-        "asset:artifact/0087.sheep_blessing/register",
         "asset:artifact/0088.fertility_hoe/register",
         "asset:artifact/0103.necronomicon/register",
         "asset:artifact/0106.stone_cutter_blade/register",


### PR DESCRIPTION
現状30島攻略で開放