### PR TITLE
🐛 [Mob 213] TerribleSonicBomberの巡航ミサイル(クラスター弾)の不具合修正

### DIFF
--- a/Asset/data/asset/functions/mob/0213.terrible_sonic_bomber/tick/weapons/storm_shadow_cluster_prepare.mcfunction
+++ b/Asset/data/asset/functions/mob/0213.terrible_sonic_bomber/tick/weapons/storm_shadow_cluster_prepare.mcfunction
@@ -23,7 +23,8 @@
 # 攻撃箇所表示
     data modify storage api: Argument.FieldOverride set value {Color:16737792,Tick:50,Scale:40f}
     data modify storage api: Argument.ID set value 2201
-    execute at @p[tag=5X.StormShadowTarget] positioned ~ ~0.01 ~ run function api:object/summon
+    execute if entity @p[tag=5X.StormShadowTarget] at @p[tag=5X.StormShadowTarget] positioned ~ ~0.01 ~ run function api:object/summon
+    execute unless entity @p[tag=5X.StormShadowTarget] at @e[type=marker,tag=5X.Centre,distance=..128,limit=1] positioned ~ ~0.01 ~ run function api:object/summon
 
 # reset
     scoreboard players reset $attack_start_time Temporary

--- a/Asset/data/asset/functions/object/2086.storm_shadow_cluster/kill/summon_munitions.mcfunction
+++ b/Asset/data/asset/functions/object/2086.storm_shadow_cluster/kill/summon_munitions.mcfunction
@@ -11,5 +11,6 @@
 
 # クラスター弾召喚
     execute store result storage api: Argument.FieldOverride.DetonateTime int 1 run random value 20..30
+    data modify storage api: Argument.FieldOverride.MobUUID set from storage asset:context this.MobUUID
     data modify storage api: Argument.ID set value 2089
     execute positioned ~ ~0.01 ~ run function api:object/summon

--- a/Asset/data/asset/functions/object/2089.cluster_munition/register.mcfunction
+++ b/Asset/data/asset/functions/object/2089.cluster_munition/register.mcfunction
@@ -18,3 +18,4 @@
     data modify storage asset:object ID set value 2089
 # フィールド(オプション)
     data modify storage asset:object Field.DetonateTime set value 20
+    data modify storage asset:object Field.MobUUID set value 0


### PR DESCRIPTION
- 全員スペクテーターになってると攻撃予想地点が出ない問題修正
- 弾頭にMobUUIDが伝達されていなかった問題を修正