### PR TITLE
⚖[神器ID 0981] ソウルファイアバーストの性能を調整

### DIFF
--- a/Asset/data/asset/functions/artifact/0981.soulfire_burst/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0981.soulfire_burst/give/2.give.mcfunction
@@ -13,9 +13,9 @@
 # 神器のベースアイテム
     data modify storage asset:artifact Item set value "minecraft:carrot_on_a_stick"
 # 神器の名前 (TextComponentString)
-    data modify storage asset:artifact Name set value '{"text":"ソウルファイアバースト","color":"aqua"}'
+    data modify storage asset:artifact Name set value '{"text":"ソウルファイアシーカー","color":"aqua"}'
 # 神器の説明文 (TextComponentString[])
-    data modify storage asset:artifact Lore set value ['[{"text":"大きな爆発を起こす火球を放つ。","color":"white"}]','[{"text":"火球はしばらくすると、5つの小さな火球に分裂する。","color":"white"}]','{"text":"\\"青いけど全然冷たくない\\"","color":"gray"}']
+    data modify storage asset:artifact Lore set value ['[{"text":"誘導性を持つ、5つの小さな火球を放つ。","color":"white"}]','{"text":"\\"昔は非常に難しい魔法として知られていた\\"","color":"gray"}']
 # 消費アイテム ({Item: TextComponent, Count: int, Extra?: TextComponent}) (オプション)
     # data modify storage asset:artifact ConsumeItem.Item set value
     # data modify storage asset:artifact ConsumeItem.Count set value
@@ -29,7 +29,7 @@
 # 神器の発動条件 (TextComponentString) (オプション)
     # data modify storage asset:artifact Condition set value
 # 攻撃に関する情報 -Damage量 (literal[]/literal) Wikiを参照 (オプション)
-    data modify storage asset:artifact AttackInfo.Damage set value ["400-600 / 95-165x5"]
+    data modify storage asset:artifact AttackInfo.Damage set value ["95-165x5"]
 # 攻撃に関する情報 -攻撃タイプ (string[]) Wikiを参照 (オプション)
     data modify storage asset:artifact AttackInfo.AttackType set value [Magic]
 # 攻撃に関する情報 -攻撃属性 (string[]) Wikiを参照 (オプション)
@@ -45,12 +45,12 @@
 # MP必要量 (int) (オプション)
     # data modify storage asset:artifact MPRequire set value
 # MP回復量
-    data modify storage asset:artifact MPHealWhenHit set value 13
+    data modify storage asset:artifact MPHealWhenHit set value 12
 # 神器のクールダウン (int) (オプション)
-    data modify storage asset:artifact LocalCooldown set value 120
+    data modify storage asset:artifact LocalCooldown set value 80
 # 種別クールダウン ({Type: string, Duration: int}) (オプション)
     data modify storage asset:artifact TypeCooldown.Type set value "longRange"
-    data modify storage asset:artifact TypeCooldown.Duration set value 50
+    data modify storage asset:artifact TypeCooldown.Duration set value 55
 # グローバルクールダウン (int) (オプション)
     # data modify storage asset:artifact SpecialCooldown set value
 # クールダウンによる使用不可のメッセージを非表示にするか否か (boolean) (オプション)

--- a/Asset/data/asset/functions/artifact/0981.soulfire_burst/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/0981.soulfire_burst/trigger/3.main.mcfunction
@@ -16,6 +16,7 @@
     playsound minecraft:entity.witch.throw player @a ~ ~ ~ 1.5 0.5
     playsound minecraft:block.sculk_shrieker.break player @a ~ ~ ~ 1 0.8
     playsound minecraft:block.sculk_shrieker.break player @a ~ ~ ~ 1 1.2
+    playsound minecraft:block.respawn_anchor.set_spawn player @a ~ ~ ~ 1.5 2
 
 # 拡散値
     data modify storage lib: Argument.Distance set value 1

--- a/Asset/data/asset/functions/artifact/0981.soulfire_burst/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/0981.soulfire_burst/trigger/3.main.mcfunction
@@ -4,6 +4,7 @@
 #
 # @within function asset:artifact/0981.soulfire_burst/trigger/2.check_condition
 
+
 # 基本的な使用時の処理(MP消費や使用回数の処理など)を行う
     function asset:artifact/common/use/mainhand
 
@@ -16,8 +17,9 @@
     playsound minecraft:block.sculk_shrieker.break player @a ~ ~ ~ 1 0.8
     playsound minecraft:block.sculk_shrieker.break player @a ~ ~ ~ 1 1.2
 
-# 火の玉オブジェクト召喚
-    data modify storage api: Argument.ID set value 1082
-    execute store result storage api: Argument.FieldOverride.UserID int 1 run scoreboard players get @s UserID
-    data modify storage api: Argument.FieldOverride.AdditionalMPHeal set from storage api: PersistentArgument.AdditionalMPHeal
-    execute anchored eyes positioned ^ ^ ^1 run function api:object/summon
+# 拡散値
+    data modify storage lib: Argument.Distance set value 1
+    data modify storage lib: Argument.Spread set value 4
+
+# オブジェクトを放つ。ホーミングの都合で、ちょっと上向きに撃つ。
+    execute anchored eyes positioned ^ ^ ^1 rotated ~ ~-5 run function asset:artifact/0981.soulfire_burst/trigger/shoot

--- a/Asset/data/asset/functions/artifact/0981.soulfire_burst/trigger/shoot.mcfunction
+++ b/Asset/data/asset/functions/artifact/0981.soulfire_burst/trigger/shoot.mcfunction
@@ -1,0 +1,12 @@
+#> asset:artifact/0981.soulfire_burst/trigger/shoot
+#
+#
+#
+# @within function asset:artifact/0981.soulfire_burst/trigger/3.main
+
+# オブジェクトを放つ
+    function asset:artifact/0981.soulfire_burst/trigger/summon_object
+    function asset:artifact/0981.soulfire_burst/trigger/summon_object
+    function asset:artifact/0981.soulfire_burst/trigger/summon_object
+    function asset:artifact/0981.soulfire_burst/trigger/summon_object
+    function asset:artifact/0981.soulfire_burst/trigger/summon_object

--- a/Asset/data/asset/functions/artifact/0981.soulfire_burst/trigger/summon_object.mcfunction
+++ b/Asset/data/asset/functions/artifact/0981.soulfire_burst/trigger/summon_object.mcfunction
@@ -1,0 +1,30 @@
+#> asset:artifact/0981.soulfire_burst/trigger/summon_object
+#
+#
+#
+# @within function asset:artifact/0981.soulfire_burst/trigger/shoot
+
+#> SpreadLib
+# @private
+    #declare tag SpreadMarker
+
+# 拡散値
+    data modify storage lib: Argument.Distance set value 1
+    data modify storage lib: Argument.Spread set value 1
+
+# 拡散させるEntityを召喚する
+    summon marker ~ ~ ~ {Tags:["SpreadMarker"]}
+
+# 拡散
+    execute as @e[type=marker,tag=SpreadMarker,distance=..32,limit=1] run function lib:forward_spreader/circle
+
+# マーカーの方を向いて召喚
+    data modify storage api: Argument.ID set value 1083
+    execute store result storage api: Argument.FieldOverride.Damage int 1 run random value 95..165
+    execute store result storage api: Argument.FieldOverride.TargetID int 1 positioned ^ ^ ^20 run scoreboard players get @e[type=#lib:living,tag=Enemy,tag=!Uninterferable,distance=..20,sort=nearest,limit=1] MobUUID
+    execute store result storage api: Argument.FieldOverride.UserID int 1 run data get storage asset:context this.UserID
+    data modify storage api: Argument.FieldOverride.AdditionalMPHeal set from storage asset:context this.AdditionalMPHeal
+    execute facing entity @e[type=marker,tag=SpreadMarker,distance=..32,limit=1] eyes run function api:object/summon
+
+# リセット
+    kill @e[type=marker,tag=SpreadMarker,distance=..32]

--- a/Asset/data/asset/functions/object/1083.soulfire_burst_smallshot/hit_entity/.mcfunction
+++ b/Asset/data/asset/functions/object/1083.soulfire_burst_smallshot/hit_entity/.mcfunction
@@ -5,7 +5,7 @@
 # @within function asset:object/alias/1083/hit_entity
 
 # ダメージ
-    execute store result storage api: Argument.Damage float 1 run random value 95..165
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage
     data modify storage api: Argument.AttackType set value "Magic"
     data modify storage api: Argument.ElementType set value "Fire"
     data modify storage api: Argument.AdditionalMPHeal set from storage asset:context this.AdditionalMPHeal

--- a/Asset/data/asset/functions/object/1083.soulfire_burst_smallshot/recursive/.mcfunction
+++ b/Asset/data/asset/functions/object/1083.soulfire_burst_smallshot/recursive/.mcfunction
@@ -5,5 +5,6 @@
 # @within function asset:object/alias/1083/recursive
 
 # 演出
-    particle minecraft:dust 0 1 1 1 ~ ~ ~ 0 0 0 0 1
+    particle minecraft:crit ~ ~ ~ 0 0 0 0.05 1 force @a[distance=..32]
+    particle minecraft:dust 0 1 1 1 ~ ~ ~ 0 0 0 0 1 force @a[distance=..32]
     execute if predicate lib:random_pass_per/25 run particle minecraft:soul_fire_flame ~ ~ ~ 0.1 0.1 0.1 0.01 1

--- a/Asset/data/asset/functions/object/1083.soulfire_burst_smallshot/tick/.mcfunction
+++ b/Asset/data/asset/functions/object/1083.soulfire_burst_smallshot/tick/.mcfunction
@@ -8,10 +8,12 @@
     scoreboard players add @s General.Object.Tick 1
 
 # 加速
-    execute if score @s General.Object.Tick matches 6 run data modify storage asset:context this.Speed set value 2
+    execute if score @s General.Object.Tick matches 12 run data modify storage asset:context this.Speed set value 2
+    execute if score @s General.Object.Tick matches 15 run data modify storage asset:context this.Speed set value 3
+    execute if score @s General.Object.Tick matches 18 run data modify storage asset:context this.Speed set value 4
 
 # ホーミング
-    execute if score @s General.Object.Tick matches 3..40 run function asset:object/1083.soulfire_burst_smallshot/tick/homing.m with storage asset:context this
+    execute if score @s General.Object.Tick matches 8..40 run function asset:object/1083.soulfire_burst_smallshot/tick/homing.m with storage asset:context this
 
 # Super
     function asset:object/super.tick

--- a/Asset/data/asset/functions/object/1083.soulfire_burst_smallshot/tick/homing.m.mcfunction
+++ b/Asset/data/asset/functions/object/1083.soulfire_burst_smallshot/tick/homing.m.mcfunction
@@ -13,7 +13,7 @@
     execute positioned ^-35 ^ ^ run tag @e[type=#lib:living,tag=Enemy,tag=!Uninterferable,distance=..25] add NoHoming
 
 # 追尾
-    $execute facing entity @e[type=#lib:living,tag=Enemy,tag=!NoHoming,tag=!Uninterferable,distance=..20,scores={MobUUID=$(TargetID)}] eyes positioned ^ ^ ^-5 rotated as @s positioned ^ ^ ^-15 facing entity @s feet positioned as @s run tp @s ~ ~ ~ ~ ~
+    $execute facing entity @e[type=#lib:living,tag=Enemy,tag=!NoHoming,tag=!Uninterferable,distance=..20,scores={MobUUID=$(TargetID)}] eyes positioned ^ ^ ^-1 rotated as @s positioned ^ ^ ^-3 facing entity @s feet positioned as @s run tp @s ~ ~ ~ ~ ~
 
 # タグリセット
     tag @e[type=#lib:living,tag=Enemy,tag=NoHoming,tag=!Uninterferable,distance=..30] remove NoHoming


### PR DESCRIPTION
- 分裂する大弾ではなく、誘導する小型弾を放つ神器になりました。
- 子弾自体の誘導性も調整。めっちゃ当たるけど、あまりにも適当過ぎると当たらない感じ。「ボルテージストライカー」に少しエイム要求した感じ。
- 名前が「ソウルファイアシーカー」に名前が変わりました。