### PR TITLE
[MOB 338]双子のダメージ処理をstorageに切り出し

### DIFF
--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/app/attack/1.shot.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/app/attack/1.shot.mcfunction
@@ -21,7 +21,7 @@
     scoreboard players add @s 9F.BulletCount.Hg 1
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 35f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.Shot
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/app/attack/1.shot_from_warp.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/app/attack/1.shot_from_warp.mcfunction
@@ -20,7 +20,7 @@
     scoreboard players add @s 9F.BulletCount.Hg 1
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 36f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.Shot
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/app/attack/1.shot_weak.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/app/attack/1.shot_weak.mcfunction
@@ -21,7 +21,7 @@
     scoreboard players add @s 9F.BulletCount.Hg 1
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 28f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.ShotWeak
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/register.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/register.mcfunction
@@ -15,38 +15,8 @@
     data modify storage asset:mob Interferable set value true
 # 名前 (TextComponentString) (オプション)
     data modify storage asset:mob Name set value '{"text":"サフィエル","color":"#a1faf5"}'
-# 武器
-    # メインハンド (Compound(Item)) (オプション)
-        # data modify storage asset:mob Weapon.Mainhand set value
-    # オフハンド (Compound(Item)) (オプション)
-        # data modify storage asset:mob Weapon.Offhand set value
-# 武器ドロップ率 ([float, float]) (オプション)
-    # data modify storage asset:mob WeaponDropChances set value
-# 防具
-    # 頭 (Compound(Item)) (オプション)
-        # data modify storage asset:mob Armor.Head set value
-    # 胴 (Compound(Item)) (オプション)
-        # data modify storage asset:mob Armor.Chest set value
-    # 脚 (Compound(Item)) (オプション)
-        # data modify storage asset:mob Armor.Legs set value
-    # 足 (Compound(Item)) (オプション)
-        # data modify storage asset:mob Armor.Feet set value
-# 防具ドロップ率 ([float, float]) (オプション)
-    # data modify storage asset:mob ArmorDropChances set value
 # 体力 (double) (オプション)
     data modify storage asset:mob Health set value 100000
-# 攻撃力 (double) (オプション)
-    # data modify storage asset:mob AttackDamage set value
-# 防御力 (double) (オプション) // 被ダメージがある程度大きい場合1ptにつき0.8%カット、小さい場合1ptにつき約4%カット 20pt以上は頭打ち
-    # data modify storage asset:mob Defense set value
-# 特殊防御力 (double) (オプション) // 4pointにつきダメージを大きく減らす
-    # data modify storage asset:mob SpecialDefense set value
-# 移動速度 (double) (オプション)
-    # data modify storage asset:mob Speed set value
-# 索敵範囲 (double) (オプション)
-    # data modify storage asset:mob FollowRange set value
-# ノックバック耐性 (double) (オプション)
-    # data modify storage asset:mob KnockBackResist set value
 # 属性倍率 // 1.0fで100% 最低でも25%は軽減されずに入る
     # 物理倍率 (float) (オプション)
         data modify storage asset:mob Resist.Physical set value 0.5f
@@ -58,3 +28,36 @@
         data modify storage asset:mob Resist.Water set value 1.0f
     # 雷倍率 (float) (オプション)
         data modify storage asset:mob Resist.Thunder set value 1.0f
+
+# ダメージ
+# 射撃
+    # 奇数
+        data modify storage asset:mob Field.Damage.Shot set value 36f
+    # 偶数(低威力)
+        data modify storage asset:mob Field.Damage.ShotWeak set value 28f
+# ライダーキック
+    # ライダーキック
+        data modify storage asset:mob Field.Damage.RiderKick set value 48f
+    # 回し蹴り
+        data modify storage asset:mob Field.Damage.SpinKick set value 45f
+    # 連続蹴り・最大3ヒット
+        data modify storage asset:mob Field.Damage.KickCombo set value 38f
+# 正拳突き
+    # 正拳突き
+        data modify storage asset:mob Field.Damage.Punch set value 55f
+    # 足払い・この後の追撃が本番のため、ダメージは低い
+        data modify storage asset:mob Field.Damage.LowKick set value 10f
+# ワープ
+    # かかと落とし
+        data modify storage asset:mob Field.Damage.HeelOff set value 50f
+    # 後ろ回し蹴り・最大2ヒット
+        data modify storage asset:mob Field.Damage.HeelSpin set value 40f
+    # 上の後射撃
+# ロケラン
+    data modify storage asset:mob Field.Damage.Launcher set value 65f
+# 怯み庇い
+    # ライダーキック・RiderKickを使用
+    # 回し蹴り
+        data modify storage asset:mob Field.Damage.CoverSpin set value 42f
+    # 足払い
+        data modify storage asset:mob Field.Damage.CoverLow set value 48f

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/05_1_hg_spinkick/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/05_1_hg_spinkick/5.damage.mcfunction
@@ -9,7 +9,7 @@
     tag @a[tag=!PlayerShouldInvulnerable,distance=..2.8] add 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 45f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.SpinKick
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/05_2_hg_kickcombo/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/05_2_hg_kickcombo/5.damage.mcfunction
@@ -9,7 +9,7 @@
     tag @a[tag=!PlayerShouldInvulnerable,distance=..2] add 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 38f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.KickCombo
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/05_hg_riderkick/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/05_hg_riderkick/5.damage.mcfunction
@@ -9,7 +9,7 @@
     tag @a[tag=!PlayerShouldInvulnerable,distance=..2] add 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 42f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.RiderKick
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/06_1_hg_lowkick/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/06_1_hg_lowkick/5.damage.mcfunction
@@ -10,7 +10,7 @@
     execute as @a[tag=9F.Temp.Target.Attack] at @s if block ~ ~-1 ~ #lib:no_collision run tag @s remove 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 10f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.LowKick
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/06_hg_punch/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/06_hg_punch/5.damage.mcfunction
@@ -9,7 +9,7 @@
     tag @a[tag=!PlayerShouldInvulnerable,distance=..2] add 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 55f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.Punch
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
@@ -26,7 +26,11 @@
     execute if entity @a[tag=9F.Temp.Target.Attack] run playsound ogg:entity.player.attack.knockback2 hostile @a ~ ~ ~ 2 0.8
 
 # 鈍足付与
-    effect give @a[tag=9F.Temp.Target.Attack] slowness 5 3
+    data modify storage api: Argument.ID set value 17
+    data modify storage api: Argument.Stack set value 2
+    data modify storage api: Argument.Duration set value 100
+    execute as @a[tag=9F.Temp.Target.Attack,distance=..30] run function api:entity/mob/effect/give
+    function api:entity/mob/effect/reset
 
 # 終了
     tag @a[tag=9F.Temp.Target.Attack] remove 9F.Temp.Target.Attack

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/07_2_hg_heeloff/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/07_2_hg_heeloff/5.damage.mcfunction
@@ -10,7 +10,7 @@
     execute positioned ^ ^ ^2.5 run tag @a[tag=!PlayerShouldInvulnerable,distance=..1.4] add 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 50f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.HeelOff
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/07_3_hg_heelspin/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/07_3_hg_heelspin/5.damage.mcfunction
@@ -9,7 +9,7 @@
     tag @a[tag=!PlayerShouldInvulnerable,distance=..2.8] add 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 40f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.HeelSpin
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/22_3_lc_shot_shot/5.1.shot.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/22_3_lc_shot_shot/5.1.shot.mcfunction
@@ -15,7 +15,7 @@
 # ミサイル召喚
     execute facing entity @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] feet run tp @s ~ ~ ~ ~ ~
     data modify storage api: Argument.ID set value 2199
-    data modify storage api: Argument.FieldOverride.Damage set value 60.0f
+    data modify storage api: Argument.FieldOverride.Damage set from storage asset:context this.Damage.Launcher
     data modify storage api: Argument.FieldOverride.Rotation set from entity @s Rotation
     execute store result storage api: Argument.FieldOverride.MobUUID int 1 run scoreboard players get @s MobUUID
     execute positioned ^ ^1 ^1 run function api:object/summon

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/41_cover/5.1.damage_rider.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/41_cover/5.1.damage_rider.mcfunction
@@ -9,7 +9,7 @@
     tag @a[distance=..2] add 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 42f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.RiderKick
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/41_cover/5.2.damage_spin.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/41_cover/5.2.damage_spin.mcfunction
@@ -9,7 +9,7 @@
     tag @a[distance=..2.8] add 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 45f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.CoverSpin
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/41_cover/5.3.damage_low.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/41_cover/5.3.damage_low.mcfunction
@@ -10,7 +10,7 @@
     execute as @a[tag=9F.Temp.Target.Attack] at @s if block ~ ~-1 ~ #lib:no_collision run tag @s remove 9F.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 52f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.CoverLow
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/register.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/register.mcfunction
@@ -15,38 +15,8 @@
     data modify storage asset:mob Interferable set value true
 # 名前 (TextComponentString) (オプション)
     data modify storage asset:mob Name set value '{"text":"ルビエル","color":"#ffbfd4"}'
-# 武器
-    # メインハンド (Compound(Item)) (オプション)
-        # data modify storage asset:mob Weapon.Mainhand set value
-    # オフハンド (Compound(Item)) (オプション)
-        # data modify storage asset:mob Weapon.Offhand set value
-# 武器ドロップ率 ([float, float]) (オプション)
-    # data modify storage asset:mob WeaponDropChances set value
-# 防具
-    # 頭 (Compound(Item)) (オプション)
-        # data modify storage asset:mob Armor.Head set value
-    # 胴 (Compound(Item)) (オプション)
-        # data modify storage asset:mob Armor.Chest set value
-    # 脚 (Compound(Item)) (オプション)
-        # data modify storage asset:mob Armor.Legs set value
-    # 足 (Compound(Item)) (オプション)
-        # data modify storage asset:mob Armor.Feet set value
-# 防具ドロップ率 ([float, float]) (オプション)
-    # data modify storage asset:mob ArmorDropChances set value
 # 体力 (double) (オプション)
     data modify storage asset:mob Health set value 100000
-# 攻撃力 (double) (オプション)
-    # data modify storage asset:mob AttackDamage set value
-# 防御力 (double) (オプション) // 被ダメージがある程度大きい場合1ptにつき0.8%カット、小さい場合1ptにつき約4%カット 20pt以上は頭打ち
-    # data modify storage asset:mob Defense set value
-# 特殊防御力 (double) (オプション) // 4pointにつきダメージを大きく減らす
-    # data modify storage asset:mob SpecialDefense set value
-# 移動速度 (double) (オプション)
-    # data modify storage asset:mob Speed set value
-# 索敵範囲 (double) (オプション)
-    # data modify storage asset:mob FollowRange set value
-# ノックバック耐性 (double) (オプション)
-    # data modify storage asset:mob KnockBackResist set value
 # 属性倍率 // 1.0fで100% 最低でも25%は軽減されずに入る
     # 物理倍率 (float) (オプション)
         data modify storage asset:mob Resist.Physical set value 1.0f
@@ -58,3 +28,66 @@
         data modify storage asset:mob Resist.Water set value 1.0f
     # 雷倍率 (float) (オプション)
         data modify storage asset:mob Resist.Thunder set value 1.0f
+
+# ダメージ
+# 移動斬り
+    # 移動斬り
+        data modify storage asset:mob Field.Damage.MoveSlash set value 48f
+    # 突き
+        data modify storage asset:mob Field.Damage.MoveSpear set value 55f
+    # 真空斬り
+        data modify storage asset:mob Field.Damage.VacuSlash set value 65f
+    # 真空斬り追撃
+        data modify storage asset:mob Field.Damage.VacuSlashImpact set value 70f
+# 斬り下がり
+    # 斬り下がり・最大2ヒット
+        data modify storage asset:mob Field.Damage.DoubleSlash set value 42f
+# ワープ
+    # 攻撃・最大2ヒット
+        data modify storage asset:mob Field.Damage.WarpSlash set value 40f
+    # 投げナイフ
+        data modify storage asset:mob Field.Damage.WarpKnife set value 45f
+    # 突き
+        data modify storage asset:mob Field.Damage.WarpSpear set value 55f
+# 納刀
+    # カウンター
+        data modify storage asset:mob Field.Damage.IaiCounter set value 45f
+    # 十文字・最大2ヒット
+        data modify storage asset:mob Field.Damage.Iai set value 50f
+# 飛び込み
+    # 飛び込み斬り
+        data modify storage asset:mob Field.Damage.JumpSlash set value 50f
+    # 水平斬り
+        data modify storage asset:mob Field.Damage.Horizon set value 48f
+    # 二刀流水平斬り・最大2ヒット
+        data modify storage asset:mob Field.Damage.DualHorison set value 42f
+    # 二刀流回転斬り・ヒット数不安定
+        data modify storage asset:mob Field.Damage.DualSpin set value 35f
+    # 二刀流交差斬り
+        data modify storage asset:mob Field.Damage.DualCross set value 60f
+    # キャンセル投げナイフ
+        data modify storage asset:mob Field.Damage.CancelKnife set value 45f
+# 大外刈り
+    # 掴み・ダメージはほぼ演出用
+        data modify storage asset:mob Field.Damage.Catch set value 5f
+    # 投げ・ダメージはほぼ演出用
+        data modify storage asset:mob Field.Damage.Throw set value 10f
+    # 追撃
+        data modify storage asset:mob Field.Damage.ThrowSlash set value 55f
+# シンクロ・交差攻撃
+    # 斬り上げ
+        data modify storage asset:mob Field.Damage.SyncUpper set value 5f
+# シンクロ・ルビィぶん投げ
+    # 直撃
+        data modify storage asset:mob Field.Damage.SyncThrowNear set value 65f
+    # 外側
+        data modify storage asset:mob Field.Damage.SyncThrowFar set value 55f
+    # 追撃
+        data modify storage asset:mob Field.Damage.SyncThrowImpact set value 50f
+# 怯み庇い
+    # 飛び込み斬り
+        data modify storage asset:mob Field.Damage.CoverJump set value 50f
+    # 二刀流水平斬り・最大2ヒット
+        data modify storage asset:mob Field.Damage.CoverHorizon set value 42f
+    # 二刀流交差斬り
+        data modify storage asset:mob Field.Damage.CoverDual set value 58f

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_1_kt_moveslash/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_1_kt_moveslash/5.damage.mcfunction
@@ -10,7 +10,7 @@
     execute positioned ^ ^ ^1.5 run tag @a[tag=!PlayerShouldInvulnerable,distance=..2] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 42f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.MoveSlash
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_2_kt_movetospear/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_2_kt_movetospear/5.damage.mcfunction
@@ -12,7 +12,7 @@
     tag @a[tag=9G.Temp.Target.JumpAvoid] remove 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 50f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.MoveSpear
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_4_kt_vacuslash/5.1.damage_slash.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_4_kt_vacuslash/5.1.damage_slash.mcfunction
@@ -14,7 +14,7 @@
     execute positioned ^ ^ ^10 run tag @a[tag=!PlayerShouldInvulnerable,distance=..3] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 55f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.VacuSlash
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_4_kt_vacuslash/5.2.damage_impact.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/03_4_kt_vacuslash/5.2.damage_impact.mcfunction
@@ -11,7 +11,7 @@
     execute positioned ^ ^ ^3 run tag @a[tag=!PlayerShouldInvulnerable,distance=..2] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 70f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.VacuSlashImpact
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/04_1_kt_doubleslash/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/04_1_kt_doubleslash/5.damage.mcfunction
@@ -9,7 +9,7 @@
     tag @a[tag=!PlayerShouldInvulnerable,distance=..2.3] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 36f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.DoubleSlash
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/05_1_kt_setwarp/5.1.damage_slash.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/05_1_kt_setwarp/5.1.damage_slash.mcfunction
@@ -9,7 +9,7 @@
     execute positioned ^ ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..3] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 38f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.WarpSlash
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/05_1_kt_setwarp/5.2.throw_knife.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/05_1_kt_setwarp/5.2.throw_knife.mcfunction
@@ -13,19 +13,19 @@
 # ナイフ召喚
     execute facing entity @e[type=area_effect_cloud,tag=9G.Temp.Target.Aec.0,sort=nearest,limit=1] feet run tp @s ~ ~ ~ ~ ~3
     data modify storage api: Argument.ID set value 2197
-    data modify storage api: Argument.FieldOverride.Damage set value 40.0f
+    data modify storage api: Argument.FieldOverride.Damage set from storage asset:context this.Damage.WarpKnife
     data modify storage api: Argument.FieldOverride.Rotation set from entity @s Rotation
     execute store result storage api: Argument.FieldOverride.MobUUID int 1 run scoreboard players get @s MobUUID
     execute positioned ^ ^1.2 ^1 run function api:object/summon
     execute at @s run tp @s ~ ~ ~ ~-18 ~
     data modify storage api: Argument.ID set value 2197
-    data modify storage api: Argument.FieldOverride.Damage set value 40.0f
+    data modify storage api: Argument.FieldOverride.Damage set from storage asset:context this.Damage.WarpKnife
     data modify storage api: Argument.FieldOverride.Rotation set from entity @s Rotation
     execute store result storage api: Argument.FieldOverride.MobUUID int 1 run scoreboard players get @s MobUUID
     execute positioned ^ ^1.2 ^1 run function api:object/summon
     execute at @s run tp @s ~ ~ ~ ~36 ~
     data modify storage api: Argument.ID set value 2197
-    data modify storage api: Argument.FieldOverride.Damage set value 40.0f
+    data modify storage api: Argument.FieldOverride.Damage set from storage asset:context this.Damage.WarpKnife
     data modify storage api: Argument.FieldOverride.Rotation set from entity @s Rotation
     execute store result storage api: Argument.FieldOverride.MobUUID int 1 run scoreboard players get @s MobUUID
     execute positioned ^ ^1.2 ^1 run function api:object/summon

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/05_1_kt_setwarp/5.3.damage_spear.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/05_1_kt_setwarp/5.3.damage_spear.mcfunction
@@ -12,7 +12,7 @@
     tag @a[tag=9G.Temp.Target.JumpAvoid] remove 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 50f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.WarpSpear
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/06_3_kt_draw_jumonji/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/06_3_kt_draw_jumonji/5.damage.mcfunction
@@ -9,7 +9,7 @@
     execute positioned ^ ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..3] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 45f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.Iai
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/06_5_kt_sheathe_counter/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/06_5_kt_sheathe_counter/5.damage.mcfunction
@@ -1,6 +1,6 @@
 #> asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/06_5_kt_sheathe_counter/5.damage
 #
-# アニメーションのイベントハンドラ Kt斬り下がり ダメージ判定
+# アニメーションのイベントハンドラ Kt居合斬り カウンター ダメージ判定
 #
 # @within
 #    function asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/06_5_kt_sheathe_counter/1.main
@@ -9,7 +9,7 @@
     tag @a[tag=!PlayerShouldInvulnerable,distance=..1.2] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 45f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.IaiCounter
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_1_kt_jumpslash/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_1_kt_jumpslash/5.damage.mcfunction
@@ -9,7 +9,7 @@
     execute positioned ^ ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..2] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 40f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.JumpSlash
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_2_kt_horizon/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_2_kt_horizon/5.damage.mcfunction
@@ -11,7 +11,7 @@
     execute positioned ^2 ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..2] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 40f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.Horizon
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_3_kt_horizon_double/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_3_kt_horizon_double/5.damage.mcfunction
@@ -9,7 +9,7 @@
     execute positioned ^ ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..3] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 40f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.DualHorison
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_4_kt_dashattack/5.1.damage_spin.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_4_kt_dashattack/5.1.damage_spin.mcfunction
@@ -11,7 +11,7 @@
     execute positioned ^ ^ ^1.5 run tag @a[tag=!PlayerShouldInvulnerable,distance=..2.5] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 30f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.DualSpin
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_4_kt_dashattack/5.2.damage_cross.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_4_kt_dashattack/5.2.damage_cross.mcfunction
@@ -8,8 +8,8 @@
 # ヒット判定
     execute positioned ^ ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..3] add 9G.Temp.Target.Attack
 
-# TODO:ダメージ
-    data modify storage api: Argument.Damage set value 55f
+# ダメージ
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.DualCross
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_5_kt_backjump/5.throw_knife.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/07_5_kt_backjump/5.throw_knife.mcfunction
@@ -13,19 +13,19 @@
 # ナイフ召喚
     execute facing entity @e[type=area_effect_cloud,tag=9G.Temp.Target.Aec.0,sort=nearest,limit=1] feet run tp @s ~ ~ ~ ~ ~3
     data modify storage api: Argument.ID set value 2197
-    data modify storage api: Argument.FieldOverride.Damage set value 40.0f
+    data modify storage api: Argument.FieldOverride.Damage set from storage asset:context this.Damage.CancelKnife
     data modify storage api: Argument.FieldOverride.Rotation set from entity @s Rotation
     execute store result storage api: Argument.FieldOverride.MobUUID int 1 run scoreboard players get @s MobUUID
     execute positioned ^ ^1.2 ^1 run function api:object/summon
     execute at @s run tp @s ~ ~ ~ ~-18 ~
     data modify storage api: Argument.ID set value 2197
-    data modify storage api: Argument.FieldOverride.Damage set value 40.0f
+    data modify storage api: Argument.FieldOverride.Damage set from storage asset:context this.Damage.CancelKnife
     data modify storage api: Argument.FieldOverride.Rotation set from entity @s Rotation
     execute store result storage api: Argument.FieldOverride.MobUUID int 1 run scoreboard players get @s MobUUID
     execute positioned ^ ^1.2 ^1 run function api:object/summon
     execute at @s run tp @s ~ ~ ~ ~36 ~
     data modify storage api: Argument.ID set value 2197
-    data modify storage api: Argument.FieldOverride.Damage set value 40.0f
+    data modify storage api: Argument.FieldOverride.Damage set from storage asset:context this.Damage.CancelKnife
     data modify storage api: Argument.FieldOverride.Rotation set from entity @s Rotation
     execute store result storage api: Argument.FieldOverride.MobUUID int 1 run scoreboard players get @s MobUUID
     execute positioned ^ ^1.2 ^1 run function api:object/summon

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/08_2_kt_throw/5.1.damage_catch.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/08_2_kt_throw/5.1.damage_catch.mcfunction
@@ -9,7 +9,7 @@
     tag @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 5f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.Catch
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/08_2_kt_throw/5.2.damage_throw.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/08_2_kt_throw/5.2.damage_throw.mcfunction
@@ -9,7 +9,7 @@
     tag @a[tag=!PlayerShouldInvulnerable,sort=nearest,limit=1] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 5f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.Throw
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/31_2_sync_crossfire_upper/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/31_2_sync_crossfire_upper/5.damage.mcfunction
@@ -1,6 +1,6 @@
 #> asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/31_2_sync_crossfire_upper/5.damage
 #
-# アニメーションのイベントハンドラ Kt斬り下がり ダメージ判定
+# アニメーションのイベントハンドラ Sync交差攻撃・斬り上げ ダメージ判定
 #
 # @within
 #    function asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/31_2_sync_crossfire_upper/1.main
@@ -10,7 +10,7 @@
     execute positioned ^ ^ ^1.6 run tag @a[tag=!PlayerShouldInvulnerable,distance=..2] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 45f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.SyncUpper
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/32_1_sync_throw/5.1.damage_slash.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/32_1_sync_throw/5.1.damage_slash.mcfunction
@@ -9,7 +9,7 @@
     execute positioned ^ ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..5] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 62f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.SyncThrowNear
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier
@@ -20,7 +20,7 @@
     execute positioned ^ ^ ^ run tag @a[distance=..8.5] add 9G.Temp.Target.Attack.Sub
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 50f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.SyncThrowFar
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/32_1_sync_throw/5.2.damage_burst.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/32_1_sync_throw/5.2.damage_burst.mcfunction
@@ -13,7 +13,7 @@
     execute positioned ^ ^1 ^ rotated ~240 ~ run function asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/32_1_sync_throw/6.5.particle_line_burst
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 55f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.SyncThrowImpact
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/41_cover/5.1.damage_jump.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/41_cover/5.1.damage_jump.mcfunction
@@ -9,7 +9,7 @@
     execute positioned ^ ^ ^ run tag @a[distance=..2] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 40f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.CoverJump
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/41_cover/5.2.damage_horizon.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/41_cover/5.2.damage_horizon.mcfunction
@@ -9,7 +9,7 @@
     execute positioned ^ ^ ^ run tag @a[distance=..3] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 40f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.CoverHorizon
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/41_cover/5.3.damage_cross.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/41_cover/5.3.damage_cross.mcfunction
@@ -9,7 +9,7 @@
     execute positioned ^ ^ ^ run tag @a[distance=..3] add 9G.Temp.Target.Attack
 
 # TODO:ダメージ
-    data modify storage api: Argument.Damage set value 52f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.CoverDual
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.ElementType set value "None"
     function api:damage/modifier


### PR DESCRIPTION
- 双子のダメージ数値をregisterで定義、storageを用いて管理するように変更
- それ以外の変更点は無し