### PR TITLE
⚖[Mob 0311] ブレイジング・インフェルノの常時レーザーの発動地点が見えない問題を修正/ ついでに数が増えた

### DIFF
--- a/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/base_move/passive_laser/.mcfunction
+++ b/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/base_move/passive_laser/.mcfunction
@@ -16,11 +16,12 @@
     scoreboard players operation $Interval Temporary = @s 8N.PassiveLaser
 
 # 数Tickおきに発動する
-    scoreboard players operation $Interval Temporary %= $29 Const
+    scoreboard players operation $Interval Temporary %= $30 Const
     execute if score $Interval Temporary matches 0 run function asset:mob/0311.blazing_inferno/tick/base_move/passive_laser/summon
     execute if score $Interval Temporary matches 0 run function asset:mob/0311.blazing_inferno/tick/base_move/passive_laser/summon
     execute if score $Interval Temporary matches 0 run function asset:mob/0311.blazing_inferno/tick/base_move/passive_laser/summon
-
+    execute if score $Interval Temporary matches 0 run function asset:mob/0311.blazing_inferno/tick/base_move/passive_laser/summon
+    execute if score $Interval Temporary matches 0 run function asset:mob/0311.blazing_inferno/tick/base_move/passive_laser/summon
 # リセット
     execute if score $Interval Temporary matches 0 run scoreboard players reset @s 8N.PassiveLaser
     scoreboard players reset $Interval Temporary

--- a/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/base_move/passive_laser/summon.mcfunction
+++ b/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/base_move/passive_laser/summon.mcfunction
@@ -17,7 +17,7 @@
         summon marker ~ ~ ~ {Tags:["SpreadMarker"]}
         data modify storage lib: Argument.Bounds set value [[16d,16d],[0.0d,0.0d],[16d,16d]]
     # スポーン地点のマーカーがちょっと浮いてる関係で調整している
-        execute as @e[type=marker,tag=SpreadMarker,distance=..64] at @e[type=marker,tag=8N.Marker.SpawnPoint,distance=..64,limit=1] positioned ~ ~ ~ run function lib:spread_entity/
+        execute as @e[type=marker,tag=SpreadMarker,distance=..64] at @e[type=marker,tag=8N.Marker.SpawnPoint,distance=..64,limit=1] run function lib:spread_entity/
     # 召喚
         execute at @e[type=marker,tag=SpreadMarker,distance=..64] run function api:object/summon
     # 片付け

--- a/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/base_move/passive_laser/summon.mcfunction
+++ b/Asset/data/asset/functions/mob/0311.blazing_inferno/tick/base_move/passive_laser/summon.mcfunction
@@ -17,7 +17,7 @@
         summon marker ~ ~ ~ {Tags:["SpreadMarker"]}
         data modify storage lib: Argument.Bounds set value [[16d,16d],[0.0d,0.0d],[16d,16d]]
     # スポーン地点のマーカーがちょっと浮いてる関係で調整している
-        execute as @e[type=marker,tag=SpreadMarker,distance=..64] at @e[type=marker,tag=8N.Marker.SpawnPoint,distance=..64,limit=1] positioned ~ ~-0.5 ~ run function lib:spread_entity/
+        execute as @e[type=marker,tag=SpreadMarker,distance=..64] at @e[type=marker,tag=8N.Marker.SpawnPoint,distance=..64,limit=1] positioned ~ ~ ~ run function lib:spread_entity/
     # 召喚
         execute at @e[type=marker,tag=SpreadMarker,distance=..64] run function api:object/summon
     # 片付け


### PR DESCRIPTION
- 天使の召喚位置を勘違いしていたりしたなどの理由で、常時レーザーの発動地点は召喚位置から0.5下だったのですが、多分本番環境だと地面に埋まって見えなくなってしまうので修正。今まで報告が来なかったの、それだけ影が薄い攻撃なんでしょうね…
- Blesslessはやりたい放題らしいので、後半戦時の常時レーザーの数が2本増えました。大して変わりはしないでしょうが…。