### PR TITLE
🧑‍💻 一部Mobが持つ武器のCustomModelDataを神器と統一

### DIFF
--- a/Asset/data/asset/functions/mob/0078.messenger_of_thunder/hurt/check_health.mcfunction
+++ b/Asset/data/asset/functions/mob/0078.messenger_of_thunder/hurt/check_health.mcfunction
@@ -14,6 +14,6 @@
     execute store result score $HealthPer Temporary run data get storage api: Return.HealthPer 100
 
 # 体力半分以下を検知
-    execute if score $HealthPer Temporary matches ..50 run item replace entity @s weapon.mainhand with bow{CustomModelData:20188,Enchantments:[{id:"punch",lvl:3s}]}
+    execute if score $HealthPer Temporary matches ..50 run data modify entity @s HandItems[0].tag.Enchantments set value [{id:"punch",lvl:3s}]
     execute if score $HealthPer Temporary matches ..50 run tag @s add 26.HPLess50Per
     scoreboard players reset $HealthPer Temporary

--- a/Asset/data/asset/functions/mob/0078.messenger_of_thunder/register.mcfunction
+++ b/Asset/data/asset/functions/mob/0078.messenger_of_thunder/register.mcfunction
@@ -25,7 +25,7 @@
     # data modify storage asset:mob Lore set value
 # 武器
     # メインハンド (Compound(Item)) (オプション)
-        data modify storage asset:mob Weapon.Mainhand set value {id:"minecraft:bow",Count:1b,tag:{CustomModelData:20188,Enchantments:[{id:"punch",lvl:1s}]}}
+        data modify storage asset:mob Weapon.Mainhand set value {id:"minecraft:bow",Count:1b,tag:{CustomModelData:1061,Enchantments:[{id:"punch",lvl:1s}]}}
     # オフハンド (Compound(Item)) (オプション)
         data modify storage asset:mob Weapon.Offhand set value {id:"minecraft:carrot_on_a_stick",Count:1b,tag:{CustomModelData:376}}
 # 武器ドロップ率 ([float, float]) (オプション)

--- a/Asset/data/asset/functions/mob/0141.honey_archer/register.mcfunction
+++ b/Asset/data/asset/functions/mob/0141.honey_archer/register.mcfunction
@@ -11,7 +11,7 @@
     data modify storage asset:mob Name set value '{"text":"ハニーアーチャー","color":"#FFBD24"}'
 # 武器
     # メインハンド (Compound(Item)) (オプション)
-        data modify storage asset:mob Weapon.Mainhand set value {id:"bow",Count:1b,tag:{CustomModelData:20186}}
+        data modify storage asset:mob Weapon.Mainhand set value {id:"bow",Count:1b,tag:{CustomModelData:1262}}
     # オフハンド (Compound(Item)) (オプション)
         data modify storage asset:mob Weapon.Offhand set value {id:"minecraft:tipped_arrow",Count:1b,tag:{CustomPotionColor:16760100}}
 # 武器ドロップ率 ([float, float]) (オプション)

--- a/Asset/data/asset/functions/mob/0233.honey_flyer/register.mcfunction
+++ b/Asset/data/asset/functions/mob/0233.honey_flyer/register.mcfunction
@@ -11,7 +11,7 @@
     data modify storage asset:mob Name set value '{"text":"ハニーフライヤー","color":"#FFBD24"}'
 # 武器
     # メインハンド (Compound(Item)) (オプション)
-        data modify storage asset:mob Weapon.Mainhand set value {id:"bow",Count:1b,tag:{CustomModelData:20186}}
+        data modify storage asset:mob Weapon.Mainhand set value {id:"bow",Count:1b,tag:{CustomModelData:1262}}
     # オフハンド (Compound(Item)) (オプション)
         data modify storage asset:mob Weapon.Offhand set value {id:"minecraft:tipped_arrow",Count:1b,tag:{CustomPotionColor:16760100}}
 # 武器ドロップ率 ([float, float]) (オプション)

--- a/Asset/data/asset/functions/mob/0330.aurora_reaper/attack/.mcfunction
+++ b/Asset/data/asset/functions/mob/0330.aurora_reaper/attack/.mcfunction
@@ -19,7 +19,7 @@
     playsound entity.evoker.prepare_summon hostile @a ~ ~ ~ 0.2 2 0
 
 # プレイヤーと同じ剣(鎌)の振り方
-    item replace entity @s weapon.mainhand with stick{CustomModelData:20158}
+    item replace entity @s weapon.mainhand with ender_eye{CustomModelData:1227}
 
 # ダメージ
     data modify storage api: Argument.Damage set value 40f

--- a/Asset/data/asset/functions/mob/0330.aurora_reaper/register.mcfunction
+++ b/Asset/data/asset/functions/mob/0330.aurora_reaper/register.mcfunction
@@ -11,7 +11,7 @@
     data modify storage asset:mob Name set value '[{"text":"オ","color":"#00FFE2"},{"text":"ー","color":"#00f0e5"},{"text":"ロ","color":"#00e1e9"},{"text":"ラ","color":"#00d3ec"},{"text":"リ","color":"#00c4f0"},{"text":"ー","color":"#00b6f4"},{"text":"パ","color":"#00a7f7"},{"text":"ー","color":"#008bff"}]'
 # 武器
     # メインハンド (Compound(Item)) (オプション)
-        data modify storage asset:mob Weapon.Mainhand set value {id:"minecraft:stick",Count:1b,tag:{CustomModelData:20158}}
+        data modify storage asset:mob Weapon.Mainhand set value {id:"minecraft:ender_eye",Count:1b,tag:{CustomModelData:1227}}
     # オフハンド (Compound(Item)) (オプション)
         # data modify storage asset:mob Weapon.Offhand set value
 # 武器ドロップ率 ([float, float]) (オプション)


### PR DESCRIPTION
後から神器が実装された奴らだからしょうがないよね