### PR TITLE
🐛[Mob1005] 忠誠の幻想のアニメ再生処理にtweenじゃないのが混ざってた

### DIFF
--- a/Asset/data/asset/functions/mob/1005.illusion_of_loyalty/tick/moveset/skill/thunder/random_thunder/windup.mcfunction
+++ b/Asset/data/asset/functions/mob/1005.illusion_of_loyalty/tick/moveset/skill/thunder/random_thunder/windup.mcfunction
@@ -5,4 +5,4 @@
 # @within function asset:mob/1005.illusion_of_loyalty/tick/moveset/skill/thunder/random_thunder/
 
 # 自身のモデルにモーションを再生させる
-    execute as @e[type=item_display,tag=RX.ModelRoot.Target,sort=nearest,limit=1] run function animated_java:illusion_of_loyalty/animations/attack_magic_2_left/play
+    execute as @e[type=item_display,tag=RX.ModelRoot.Target,sort=nearest,limit=1] run function animated_java:illusion_of_loyalty/animations/attack_magic_2_left/tween {to_frame:0,duration:1}


### PR DESCRIPTION
- これが原因でlinter通らないやつがちらほらいる