### PR TITLE
🐛[Mob0055] ヘトゥケダウのビームのヒット時、プレイヤーの補正を使ってダメージを与えるのを修正

### DIFF
--- a/Asset/data/asset/functions/mob/0055.hetukedah/tick/skill/otete_beam/beam/.mcfunction
+++ b/Asset/data/asset/functions/mob/0055.hetukedah/tick/skill/otete_beam/beam/.mcfunction
@@ -12,7 +12,7 @@
     particle dust 0.7 0.7 0 1 ^ ^ ^-0.5 0.1 0.1 0.1 0 3
 
 # ダメージ
-    execute positioned ~-0.5 ~-0.5 ~-0.5 as @a[tag=!PlayerShouldInvulnerable,dx=0] positioned ~0.5 ~0.5 ~0.5 run function asset:mob/0055.hetukedah/tick/skill/otete_beam/beam/hit
+    execute positioned ~-0.5 ~-0.5 ~-0.5 if entity @a[tag=!PlayerShouldInvulnerable,dx=0] positioned ~0.5 ~0.5 ~0.5 run function asset:mob/0055.hetukedah/tick/skill/otete_beam/beam/hit
 
 # 壁ヒットで炸裂
     execute unless block ^ ^ ^1 #lib:no_collision run function asset:mob/0055.hetukedah/tick/skill/otete_beam/beam/hit

--- a/Asset/data/asset/functions/mob/0055.hetukedah/tick/skill/otete_beam/big_beam/.mcfunction
+++ b/Asset/data/asset/functions/mob/0055.hetukedah/tick/skill/otete_beam/big_beam/.mcfunction
@@ -12,7 +12,7 @@
     particle dust 0.7 0.7 0 1 ^ ^ ^-0.3 0.3 0.3 0.3 0 10
 
 # ダメージ
-    execute positioned ~-0.5 ~-0.5 ~-0.5 as @a[tag=!PlayerShouldInvulnerable,dx=0] positioned ~0.5 ~0.5 ~0.5 run function asset:mob/0055.hetukedah/tick/skill/otete_beam/big_beam/hit
+    execute positioned ~-0.5 ~-0.5 ~-0.5 if entity @a[tag=!PlayerShouldInvulnerable,dx=0] positioned ~0.5 ~0.5 ~0.5 run function asset:mob/0055.hetukedah/tick/skill/otete_beam/big_beam/hit
 
 # 壁ヒットで炸裂
     execute unless block ^ ^ ^1 #lib:no_collision run function asset:mob/0055.hetukedah/tick/skill/otete_beam/big_beam/hit


### PR DESCRIPTION
Fix #1183
- 今やるべきではない感もありますが、目についたし修正楽だったので…