### PR TITLE
[MOB 380]フェーズ移行時に一部アニメーションが停止しない問題を修正

### DIFF
--- a/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/util/remove_animation_tag.mcfunction
+++ b/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/util/remove_animation_tag.mcfunction
@@ -8,21 +8,28 @@
 
 # アニメーションタグ
     tag @s remove AK.Skill.Start
+    tag @s remove AK.Skill.Move
+    tag @s remove AK.Skill.MoveS
     tag @s remove AK.Skill.IceBullet
     tag @s remove AK.Skill.IceWall
     tag @s remove AK.Skill.IceSiege
     tag @s remove AK.Skill.IceSpear
     tag @s remove AK.Skill.Punch
-    tag @s remove AK.Skill.Move
     tag @s remove AK.Skill.SuperIceBullet
+    tag @s remove AK.Skill.IceLaser
+    tag @s remove AK.Skill.IcePillar
     tag @s remove AK.Skill.SummonHato
     tag @s remove AK.Skill.Blade
     tag @s remove AK.Skill.Giant
+    tag @s remove AK.Skill.Giant.Short
     tag @s remove AK.Skill.IceBulletDuo
     tag @s remove AK.Skill.IceWallDuo
     tag @s remove AK.Skill.IcePillarDuo
+    tag @s remove AK.Skill.IceSpearDuo
+    tag @s remove AK.Skill.IceSpinner
     tag @s remove AK.Skill.Press
     tag @s remove AK.Skill.IceCremation.First
+    tag @s remove AK.Skill.IceCremation.First.Used
     tag @s remove AK.Skill.IceCremation.Dash
     tag @s remove AK.Skill.IceCremation.FourCircle
     tag @s remove AK.Skill.IceCremation.Cross


### PR DESCRIPTION
- remove_animation_tag から、一部のアニメーションのタグが抜けていたので修正。それ以外の変更は無し