### PR TITLE
:recycle: [Mob 0440] もろい訓練用の人形の死亡処理から自身の再召喚処理を削除

### DIFF
--- a/Asset/data/asset/functions/mob/0440.dps_checker_fragile/death/.mcfunction
+++ b/Asset/data/asset/functions/mob/0440.dps_checker_fragile/death/.mcfunction
@@ -10,8 +10,3 @@
 # 演出
     playsound minecraft:entity.armor_stand.break hostile @a ~ ~ ~ 1 0.8
     particle block oak_planks ~ ~1 ~ 0.2 0.5 0.2 1 20 force @a[distance=..32]
-
-# 上から新しいのが降ってくる
-    particle explosion ~ ~10 ~ 0 0 0 0 1 force @a[distance=..32]
-    data modify storage api: Argument.ID set value 440
-    execute positioned ~ ~10 ~ facing entity @p feet rotated ~ 0 run function api:mob/summon

--- a/Asset/data/asset/functions/mob/0440.dps_checker_fragile/summon/m.mcfunction
+++ b/Asset/data/asset/functions/mob/0440.dps_checker_fragile/summon/m.mcfunction
@@ -5,4 +5,4 @@
 # @within function asset:mob/0440.dps_checker_fragile/summon/
 
 # 元となるEntityを召喚する
-    $summon skeleton ~ ~ ~ {Rotation:$(Rotation),Silent:1b,Tags:["MobInit","AlwaysInvisible","AntiFallDamage"],DeathLootTable:"empty"}
+    $summon skeleton ~ ~ ~ {DeathTime:19s,Rotation:$(Rotation),Silent:1b,Tags:["MobInit","AlwaysInvisible","AntiFallDamage"],DeathLootTable:"empty"}


### PR DESCRIPTION
- コア側のトレーニングエリアの処理で再召喚を担うようになったため。