### PR TITLE
♻️ 思うところがあった神器の名前や説明文、そして演出を変更

### DIFF
--- a/Asset/data/asset/functions/artifact/0105.secret_meat/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0105.secret_meat/give/2.give.mcfunction
@@ -13,9 +13,9 @@
 # 神器のベースアイテム
     data modify storage asset:artifact Item set value "minecraft:rotten_flesh"
 # 神器の名前 (TextComponentString)
-    data modify storage asset:artifact Name set value '[{"text":"謎肉","color":"white"}]'
+    data modify storage asset:artifact Name set value '[{"text":"ナゾの肉","color":"white"}]'
 # 神器の説明文 (TextComponentString[])
-    data modify storage asset:artifact Lore set value ['{"text":"食べると体力を66.6回復し、"}','{"text":"攻撃+20%とMP回復量+50%を30秒間得るが、"}','{"text":"効果時間中は回復ができない。"}','{"text":"また、効果が終わった際に反動を受ける"}','{"text":"すごいナゾな肉塊。食べていいのだろうか？","color":"gray"}']
+    data modify storage asset:artifact Lore set value ['{"text":"食べると体力を66.6回復し、"}','{"text":"攻撃+20%とMP回復量+50%を30秒間得るが、"}','{"text":"効果時間中は回復ができない。"}','{"text":"また、効果が終わった際に反動を受ける。"}','{"text":"謎の肉塊。食べても大丈夫なのだろうか？","color":"gray"}']
 # 消費アイテム ({Item: TextComponent, Count: int, Extra?: TextComponent}) (オプション)
     # data modify storage asset:artifact ConsumeItem.Item set value
     # data modify storage asset:artifact ConsumeItem.Count set value

--- a/Asset/data/asset/functions/artifact/0105.secret_meat/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0105.secret_meat/give/2.give.mcfunction
@@ -13,9 +13,9 @@
 # 神器のベースアイテム
     data modify storage asset:artifact Item set value "minecraft:rotten_flesh"
 # 神器の名前 (TextComponentString)
-    data modify storage asset:artifact Name set value '[{"text":"ナゾの肉","color":"white"}]'
+    data modify storage asset:artifact Name set value '[{"text":"ナゾの肉","color":"red"}]'
 # 神器の説明文 (TextComponentString[])
-    data modify storage asset:artifact Lore set value ['{"text":"食べると体力を66.6回復し、"}','{"text":"攻撃+20%とMP回復量+50%を30秒間得るが、"}','{"text":"効果時間中は回復ができない。"}','{"text":"また、効果が終わった際に反動を受ける。"}','{"text":"謎の肉塊。食べても大丈夫なのだろうか？","color":"gray"}']
+    data modify storage asset:artifact Lore set value ['{"text":"食べると体力を66.6回復し、"}','{"text":"攻撃+20%とMP回復量+50%、"}','{"text":"更にジャンプ力と採掘速度の強化を30秒間得るが、"}','{"text":"効果時間中は回復ができない。"}','{"text":"また、効果が終わった際に反動でダメージを受ける。"}','{"text":"謎の肉塊。食べても大丈夫なのだろうか？","color":"gray"}']
 # 消費アイテム ({Item: TextComponent, Count: int, Extra?: TextComponent}) (オプション)
     # data modify storage asset:artifact ConsumeItem.Item set value
     # data modify storage asset:artifact ConsumeItem.Count set value

--- a/Asset/data/asset/functions/artifact/0105.secret_meat/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0105.secret_meat/give/2.give.mcfunction
@@ -13,9 +13,9 @@
 # 神器のベースアイテム
     data modify storage asset:artifact Item set value "minecraft:rotten_flesh"
 # 神器の名前 (TextComponentString)
-    data modify storage asset:artifact Name set value '[{"text":"謎肉","color":"light_purple"}]'
+    data modify storage asset:artifact Name set value '[{"text":"謎肉","color":"white"}]'
 # 神器の説明文 (TextComponentString[])
-    data modify storage asset:artifact Lore set value ['{"text":"食べると体力を66.6回復し"}','{"text":"攻撃+20%とMP回復量+50%を30秒間得るが"}','{"text":"その間は回復を拒むようになる"}','{"text":"また、効果が終わった時には反動を受ける"}','{"text":"謎に包まれた肉。なんの動物かもわからない。","color":"gray"}']
+    data modify storage asset:artifact Lore set value ['{"text":"食べると体力を66.6回復し、"}','{"text":"攻撃+20%とMP回復量+50%を30秒間得るが、"}','{"text":"効果時間中は回復ができない。"}','{"text":"また、効果が終わった際に反動を受ける"}','{"text":"すごいナゾな肉塊。食べていいのだろうか？","color":"gray"}']
 # 消費アイテム ({Item: TextComponent, Count: int, Extra?: TextComponent}) (オプション)
     # data modify storage asset:artifact ConsumeItem.Item set value
     # data modify storage asset:artifact ConsumeItem.Count set value

--- a/Asset/data/asset/functions/artifact/0105.secret_meat/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/0105.secret_meat/trigger/3.main.mcfunction
@@ -16,7 +16,7 @@
     function api:heal/
     function api:heal/reset
 
-# 自身に謎肉バフ(ID:203)を付与
+# 自身にナゾの肉バフ(ID:203)を付与
     data modify storage api: Argument.ID set value 203
     function api:entity/mob/effect/give
     function api:entity/mob/effect/reset

--- a/Asset/data/asset/functions/artifact/0317.sea_storm_sword/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0317.sea_storm_sword/give/2.give.mcfunction
@@ -13,9 +13,9 @@
 # 神器のベースアイテム
     data modify storage asset:artifact Item set value "minecraft:stick"
 # 神器の名前 (TextComponentString)
-    data modify storage asset:artifact Name set value '{"text":"荒波の剣","color":"dark_blue"}'
+    data modify storage asset:artifact Name set value '{"text":"氷晶の剣","color":"aqua"}'
 # 神器の説明文 (TextComponentString[])
-    data modify storage asset:artifact Lore set value ['{"text":"水流を纏った剣。 "}','{"text":"敵に強力な物理水属性ダメージを与える"}']
+    data modify storage asset:artifact Lore set value ['{"text":"凍てつく刀身を持つ大剣。 "}','{"text":"敵に強力な物理水属性ダメージを与える"}']
 # 消費アイテム ({Item: TextComponent, Count: int, Extra?: TextComponent}) (オプション)
     # data modify storage asset:artifact ConsumeItem.Item set value
     # data modify storage asset:artifact ConsumeItem.Count set value

--- a/Asset/data/asset/functions/artifact/0317.sea_storm_sword/trigger/vfx.mcfunction
+++ b/Asset/data/asset/functions/artifact/0317.sea_storm_sword/trigger/vfx.mcfunction
@@ -5,10 +5,9 @@
 # @within function asset:artifact/0317.sea_storm_sword/trigger/3.main
 
 # 演出
-    particle dolphin ~ ~1 ~ 0.4 0.5 0.4 0 200 normal @a
-    particle cloud ~ ~1 ~ 0.5 0.5 0.5 0.1 20
-    particle block water ~ ~ ~ 0.4 1.4 0.4 0 100
-    playsound entity.dolphin.jump player @a ~ ~ ~ 1 2
-    playsound entity.dolphin.splash player @a ~ ~ ~ 1.2 1
+    particle electric_spark ~ ~1 ~ 0.4 0.5 0.4 0.05 10 normal @a
+    particle cloud ~ ~1 ~ 0.5 0.5 0.5 0.1 10
+    particle block ice ~ ~ ~ 0.4 1.4 0.4 0 50
     playsound block.glass.break player @a ~ ~ ~ 1.2 1
-
+    playsound minecraft:entity.witch.throw player @a ~ ~ ~ 1 0.5
+    playsound minecraft:block.amethyst_block.place player @a ~ ~ ~ 1 2

--- a/Asset/data/asset/functions/artifact/0976.brave_sword/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0976.brave_sword/give/2.give.mcfunction
@@ -13,7 +13,7 @@
 # 神器のベースアイテム
     data modify storage asset:artifact Item set value "minecraft:carrot_on_a_stick"
 # 神器の名前 (TextComponentString)
-    data modify storage asset:artifact Name set value '{"text":"ブレイブソード","color":"light_purple"}'
+    data modify storage asset:artifact Name set value '{"text":"ブレイブソード","color":"#26baff"}'
 # 神器の説明文 (TextComponentString[])
     data modify storage asset:artifact Lore set value ['{"text":"複数の敵を巻き込む斬撃を放つ。"}','{"text":"コンボフィニッシュでは、敵を貫通する衝撃波を放つ。"}','{"text":"\\"勇気の刃\\"","color":"gray"}']
 # 消費アイテム ({Item: TextComponent, Count: int, Extra?: TextComponent}) (オプション)

--- a/Asset/data/asset/functions/artifact/1021.brave_book/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/1021.brave_book/give/2.give.mcfunction
@@ -13,7 +13,7 @@
 # 神器のベースアイテム
     data modify storage asset:artifact Item set value "carrot_on_a_stick"
 # 神器の名前 (TextComponentString)
-    data modify storage asset:artifact Name set value '{"text":"ブレイブブック","color":"light_purple"}'
+    data modify storage asset:artifact Name set value '{"text":"ブレイブブック","color":"#26baff"}'
 # 神器の説明文 (TextComponentString[])
     data modify storage asset:artifact Lore set value ['{"text":"付近の敵に近接攻撃を行う騎士を召喚する。","color":"white"}','{"text":"\\"勇気の物語\\"","color":"gray"}']
 # MP以外の消費物 (TextComponentString) (オプション)

--- a/Asset/data/asset/functions/artifact/1024.brave_rod/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/1024.brave_rod/give/2.give.mcfunction
@@ -13,7 +13,7 @@
 # 神器のベースアイテム
     data modify storage asset:artifact Item set value "carrot_on_a_stick"
 # 神器の名前 (TextComponentString)
-    data modify storage asset:artifact Name set value '{"text":"ブレイブロッド","color":"light_purple"}'
+    data modify storage asset:artifact Name set value '{"text":"ブレイブロッド","color":"#26baff"}'
 # 神器の説明文 (TextComponentString[])
     data modify storage asset:artifact Lore set value ['[{"text":"魔法の光線を前方に連続で放つ。","color":"white"}]','[{"text":"コンボフィニッシュの光線は、射程が少し伸びる。","color":"white"}]','[{"text":"\\"勇気の魔法\\"","color":"gray"}]']
 # 消費アイテム ({Item: TextComponent, Count: int, Extra?: TextComponent}) (オプション)

--- a/Asset/data/asset/functions/effect/0203.secret_meat/register.mcfunction
+++ b/Asset/data/asset/functions/effect/0203.secret_meat/register.mcfunction
@@ -9,9 +9,9 @@
 # ID (int)
     data modify storage asset:effect ID set value 203
 # 名前 (TextComponentString)
-    data modify storage asset:effect Name set value '{"text":"謎肉","color":"light_purple"}'
+    data modify storage asset:effect Name set value '{"text":"ナゾの肉","color":"light_purple"}'
 # 説明文 (TextComponentString[])
-    data modify storage asset:effect Description set value ['{"text":"与ダメージとMP回復量、機動力が大きく上昇するが、回復できなくなり","color":"white"}','{"text":"効果終了時、最大体力に比例したダメージを受け、MPが0になる","color":"white"}']
+    data modify storage asset:effect Description set value ['{"text":"与ダメージとMP回復量、機動力が大きく上昇するが、回復することができない","color":"white"}','{"text":"効果終了時、最大体力に比例したダメージを受け、MPが0になる","color":"white"}']
 # 効果時間 (int) (default = API || error)
     data modify storage asset:effect Duration set value 600
 # スタック (int) (default = API || 1)


### PR DESCRIPTION
- 謎肉: 「ナゾの肉」に名称変更。説明文ちょっと変わった。
- ブレイブ系3種: 文字色ピンクではないなって思ったので青くした。
- 荒波の剣: どう見ても荒波な見た目ではないので「氷晶の剣」に名前を変えて、演出もちょっと調整した。