### PR TITLE
[MOB 380]ハルクレア調整

### DIFF
--- a/Asset/data/asset/functions/object/2150.haruclaire_ice_wall/tick/kill.mcfunction
+++ b/Asset/data/asset/functions/object/2150.haruclaire_ice_wall/tick/kill.mcfunction
@@ -6,8 +6,8 @@
 
 # 演出
     particle flash ~ ~2 ~ 0 0 0 0 1
-    particle dust 0.902 0.902 1 3 ~ ~2 ~ 1 1 1 0 10
-    particle dust 0.635 0.898 1 3 ~ ~1 ~ 1 1 1 0 10
+    particle dust 0.902 0.902 1 3 ~ ~2 ~ 1 1 1 0 3
+    particle dust 0.635 0.898 1 3 ~ ~1 ~ 1 1 1 0 3
 
 # 消滅
     execute on passengers run kill @s


### PR DESCRIPTION
- プレイを見ていてパーティクルが多くて視認性が悪そうだったので、アイスウォール消滅時のパーティクルを削減
- 余裕あったら適用してほしいです
