### PR TITLE
🐛 [Mob 442] 魔法耐性の人形のIDが正しくない問題を修正

### DIFF
--- a/Asset/data/asset/functions/mob/0442.dps_checker_magical/register.mcfunction
+++ b/Asset/data/asset/functions/mob/0442.dps_checker_magical/register.mcfunction
@@ -12,7 +12,7 @@
 # 継承されることを前提とした、抽象的なモブであるかどうか(boolean)
     data modify storage asset:mob IsAbstract set value false
 # ID (int)
-    data modify storage asset:mob ID set value 441
+    data modify storage asset:mob ID set value 442
 # Type (string) Wikiを参照
     data modify storage asset:mob Type set value "Enemy"
 # 干渉可能か否か (boolean)


### PR DESCRIPTION
Fix #1414