### PR TITLE
:bug: [Mob 410] 黒龍に敗北した場合に眷属が残る問題を修正

### DIFF
--- a/Asset/data/asset/functions/mob/0410.heiloang/death/.mcfunction
+++ b/Asset/data/asset/functions/mob/0410.heiloang/death/.mcfunction
@@ -37,6 +37,10 @@
 # その他リセット
     function asset:mob/0410.heiloang/tick/util/remove_all_tag
 
+# 眷属消去
+    execute as @e[type=slime,tag=BF.EntityRoot] run function api:mob/remove
+    execute as @e[type=slime,tag=BG.EntityRoot] run function api:mob/remove
+
 # オブジェクト消去
     execute as @e[tag=BE.Object,distance=..160] on passengers run kill @s
     kill @e[tag=BE.Object,distance=..160]

--- a/Asset/data/asset/functions/mob/0410.heiloang/remove/.mcfunction
+++ b/Asset/data/asset/functions/mob/0410.heiloang/remove/.mcfunction
@@ -30,6 +30,10 @@
 # その他リセット
     function asset:mob/0410.heiloang/tick/util/remove_all_tag
 
+# 眷属消去
+    execute as @e[type=slime,tag=BF.EntityRoot] run function api:mob/remove
+    execute as @e[type=slime,tag=BG.EntityRoot] run function api:mob/remove
+
 # オブジェクト消去
     execute as @e[tag=BE.Object,distance=..160] on passengers run kill @s
     kill @e[tag=BE.Object,distance=..160]


### PR DESCRIPTION
- remove時、眷属のremoveを呼び出すようにした。通常あり得ないが、念のためdeath時も同様