### PR TITLE
🐛 [Artifact 733] 百分一剣が特定条件下でダメージが設定されない問題を修正

### DIFF
--- a/Asset/data/asset/functions/artifact/0733.percentage_sword/trigger/2.check_condition.mcfunction
+++ b/Asset/data/asset/functions/artifact/0733.percentage_sword/trigger/2.check_condition.mcfunction
@@ -8,5 +8,8 @@
     function asset:artifact/common/check_condition/mainhand
 # 他にアイテム等確認する場合はここに書く
 
+# tag=!UninterferableなVictimがいなければCanUsedを削除
+    execute unless entity @e[type=#lib:living,tag=Victim,tag=!Uninterferable,distance=..20] run tag @s remove CanUsed
+
 # CanUsedタグをチェックして3.main.mcfunctionを実行する
     execute if entity @s[tag=CanUsed] run function asset:artifact/0733.percentage_sword/trigger/3.main

--- a/Asset/data/asset/functions/artifact/0733.percentage_sword/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/0733.percentage_sword/trigger/3.main.mcfunction
@@ -17,18 +17,16 @@
     playsound block.beacon.power_select player @a ~ ~ ~ 0.4 1.8 0
     playsound block.beacon.power_select player @a ~ ~ ~ 0.4 2.0 0
 
-# 4割の割合追加ダメージまでの処理
+# 割合ダメージ
+    # 雑魚の場合は99%
+        execute as @e[type=#lib:living,tag=Victim,tag=!Enemy.Boss,tag=!Uninterferable,distance=..20] store result storage api: Argument.Damage float 0.99 run function api:mob/get_max_health
+
+    # 天使の場合は1%にする
+        execute as @e[type=#lib:living,tag=Victim,tag=Enemy.Boss,tag=!Uninterferable,distance=..20] run function asset:artifact/0733.percentage_sword/trigger/angel_damage_calc
+
     data modify storage api: Argument.AttackType set value "Magic"
     data modify storage api: Argument.ElementType set value "None"
     data modify storage api: Argument.FixedDamage set value 1b
-    execute as @e[type=#lib:living,tag=Victim,tag=!Enemy.Boss,tag=!Uninterferable,distance=..20] store result storage api: Argument.Damage float 0.99 run function api:mob/get_max_health
-
-# 天使の場合、1%にする
-    execute as @e[type=#lib:living,tag=Victim,tag=Enemy.Boss,tag=!Uninterferable,distance=..20] run function asset:artifact/0733.percentage_sword/trigger/angel_damage_calc
-
-# ダメージ
     function api:damage/modifier
     execute if data storage api: Argument.Damage as @e[type=#lib:living,tag=Victim,distance=..20] run function api:damage/
-
-# 色々リセット
     function api:damage/reset

--- a/Asset/data/asset/functions/artifact/0733.percentage_sword/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/0733.percentage_sword/trigger/3.main.mcfunction
@@ -21,14 +21,14 @@
     data modify storage api: Argument.AttackType set value "Magic"
     data modify storage api: Argument.ElementType set value "None"
     data modify storage api: Argument.FixedDamage set value 1b
-    execute as @e[type=#lib:living,tag=Victim,tag=!Enemy.Boss,tag=!Uninterferable,distance=..6] store result storage api: Argument.Damage float 0.99 run function api:mob/get_max_health
+    execute as @e[type=#lib:living,tag=Victim,tag=!Enemy.Boss,tag=!Uninterferable,distance=..20] store result storage api: Argument.Damage float 0.99 run function api:mob/get_max_health
 
 # 天使の場合、1%にする
-    execute as @e[type=#lib:living,tag=Victim,tag=Enemy.Boss,tag=!Uninterferable,distance=..6] run function asset:artifact/0733.percentage_sword/trigger/angel_damage_calc
+    execute as @e[type=#lib:living,tag=Victim,tag=Enemy.Boss,tag=!Uninterferable,distance=..20] run function asset:artifact/0733.percentage_sword/trigger/angel_damage_calc
 
 # ダメージ
     function api:damage/modifier
-    execute if data storage api: Argument.Damage as @e[type=#lib:living,tag=Victim,distance=..6] run function api:damage/
+    execute if data storage api: Argument.Damage as @e[type=#lib:living,tag=Victim,distance=..20] run function api:damage/
 
 # 色々リセット
     function api:damage/reset

--- a/Asset/data/asset/functions/artifact/0733.percentage_sword/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/0733.percentage_sword/trigger/3.main.mcfunction
@@ -24,6 +24,9 @@
     # 天使の場合は1%にする
         execute as @e[type=#lib:living,tag=Victim,tag=Enemy.Boss,tag=!Uninterferable,distance=..20] run function asset:artifact/0733.percentage_sword/trigger/angel_damage_calc
 
+    # 起こり得ないはずだが、ダメージが設定されていなければ1を設定しておく
+        execute unless data storage api: Argument.Damage run data modify storage api: Argument.Damage set value 1
+
     data modify storage api: Argument.AttackType set value "Magic"
     data modify storage api: Argument.ElementType set value "None"
     data modify storage api: Argument.FixedDamage set value 1b


### PR DESCRIPTION
Fix #1484
多分distance=..6だとExtendedCollision相手だと狭いとかそんななのかな...?
それと、Uninterferableを殴った際に終わるって問題も直した