### PR TITLE
💫[Artifact 1024] ブレイブロッドの使用時の音量調整と、ビームの見た目の強化

### DIFF
--- a/Asset/data/asset/functions/artifact/1024.brave_rod/trigger/combo/beam1.mcfunction
+++ b/Asset/data/asset/functions/artifact/1024.brave_rod/trigger/combo/beam1.mcfunction
@@ -9,8 +9,8 @@
     #declare tag SpreadMarker
 
 # 演出
-    execute positioned ^ ^ ^1 run playsound ogg:block.respawn_anchor.deplete2 player @a ~ ~ ~ 1 1.5
-    execute positioned ^ ^ ^1 run playsound tsb_sounds:blaster2 player @a ~ ~ ~ 0.6 1.5
+    execute positioned ^ ^ ^1 run playsound ogg:block.respawn_anchor.deplete2 player @a ~ ~ ~ 0.7 1.5
+    execute positioned ^ ^ ^1 run playsound tsb_sounds:blaster2 player @a ~ ~ ~ 0.3 1.5
     #execute positioned ^ ^ ^1 run playsound minecraft:entity.allay.hurt player @a ~ ~ ~ 1 2
 
 # 拡散させて実行

--- a/Asset/data/asset/functions/artifact/1024.brave_rod/trigger/combo/beam1_shot.mcfunction
+++ b/Asset/data/asset/functions/artifact/1024.brave_rod/trigger/combo/beam1_shot.mcfunction
@@ -13,5 +13,14 @@
 # ビームを撃つ
     function asset:artifact/1024.brave_rod/trigger/combo/laser
 
+# 見た目レーザーのオブジェクト召喚
+    data modify storage api: Argument.ID set value 2168
+    data modify storage api: Argument.FieldOverride set value {Scale:[0.25f,0f,0.25f],Color:50175,DisappearInterpolation:2,LifeTime:7}
+    execute store result storage api: Argument.FieldOverride.Scale[1] float 1 run scoreboard players get @s Temporary
+    function api:object/summon
+
+# リセット
+    scoreboard players reset @s Temporary
+
 # 使用者解除
     tag @s remove SG.Used

--- a/Asset/data/asset/functions/artifact/1024.brave_rod/trigger/combo/beam3_burst.mcfunction
+++ b/Asset/data/asset/functions/artifact/1024.brave_rod/trigger/combo/beam3_burst.mcfunction
@@ -9,8 +9,8 @@
     #declare tag SpreadMarker
 
 # 演出
-    execute positioned ^ ^ ^1 run playsound ogg:block.respawn_anchor.deplete1 player @a ~ ~ ~ 1 2
-    execute positioned ^ ^ ^1 run playsound tsb_sounds:blaster2 player @a ~ ~ ~ 0.6 2
+    execute positioned ^ ^ ^1 run playsound ogg:block.respawn_anchor.deplete1 player @a ~ ~ ~ 0.7 2
+    execute positioned ^ ^ ^1 run playsound tsb_sounds:blaster2 player @a ~ ~ ~ 0.3 2
     #execute positioned ^ ^ ^1 run playsound minecraft:entity.allay.hurt player @a ~ ~ ~ 1 2
 
 # 拡散させて実行

--- a/Asset/data/asset/functions/artifact/1024.brave_rod/trigger/combo/beam3_shot.mcfunction
+++ b/Asset/data/asset/functions/artifact/1024.brave_rod/trigger/combo/beam3_shot.mcfunction
@@ -13,5 +13,14 @@
 # ビームを撃つ
     function asset:artifact/1024.brave_rod/trigger/combo/laser_finish
 
+# 見た目レーザーのオブジェクト召喚
+    data modify storage api: Argument.ID set value 2168
+    data modify storage api: Argument.FieldOverride set value {Scale:[0.25f,30f,0.25f],Color:8908799,DisappearInterpolation:2,LifeTime:7}
+    execute store result storage api: Argument.FieldOverride.Scale[1] float 1 run scoreboard players get @s Temporary
+    function api:object/summon
+
+# リセット
+    scoreboard players reset @s Temporary
+
 # 使用者解除
     tag @s remove SG.Used

--- a/Asset/data/asset/functions/artifact/1024.brave_rod/trigger/combo/laser.mcfunction
+++ b/Asset/data/asset/functions/artifact/1024.brave_rod/trigger/combo/laser.mcfunction
@@ -9,16 +9,19 @@
 
 # パーティクル
     # 内側
-        particle dust 0.4 0.8 1 0.8 ^ ^ ^ 0 0 0 1 1 force @a[distance=..30]
-        particle dust 0.4 0.8 1 0.8 ^ ^ ^0.5 0 0 0 1 1 force @a[distance=..30]
-        particle dust 0.4 0.8 1 0.8 ^ ^ ^-0.5 0 0 0 1 1 force @a[distance=..30]
+        particle dust 0.4 0.8 1 0.5 ^ ^ ^ 0 0 0 1 1 force @a[distance=..30]
+        particle dust 0.4 0.8 1 0.5 ^ ^ ^0.5 0 0 0 1 1 force @a[distance=..30]
+        particle dust 0.4 0.8 1 0.5 ^ ^ ^-0.5 0 0 0 1 1 force @a[distance=..30]
     # 外側
-        particle dust 0.1 0.7 1 0.6 ^ ^ ^ 0.07 0.07 0.07 1 1 force @a[distance=..30]
-        particle dust 0.1 0.7 1 0.6 ^ ^ ^0.5 0.07 0.07 0.07 1 1 force @a[distance=..30]
-        particle dust 0.1 0.7 1 0.6 ^ ^ ^-0.5 0.07 0.07 0.07 1 1 force @a[distance=..30]
+        particle dust 0.1 0.7 1 0.3 ^ ^ ^ 0.07 0.07 0.07 1 1 force @a[distance=..30]
+        particle dust 0.1 0.7 1 0.3 ^ ^ ^0.5 0.07 0.07 0.07 1 1 force @a[distance=..30]
+        particle dust 0.1 0.7 1 0.3 ^ ^ ^-0.5 0.07 0.07 0.07 1 1 force @a[distance=..30]
 
 # ダメージ判定
     execute positioned ~-0.5 ~-0.5 ~-0.5 as @e[type=#lib:living,tag=Enemy,tag=!Uninterferable,dx=0,sort=nearest,limit=1] run function asset:artifact/1024.brave_rod/trigger/combo/laser_damage
+
+# 後でレーザーの長さを決めるためにスコア加算
+    scoreboard players add @s Temporary 1
 
 # 再帰で前に飛ばす。ヒットしてたら移動停止
     execute if entity @s[tag=!SG.Hit,distance=..18] if block ~ ~ ~ #lib:no_collision positioned ^ ^ ^1 run function asset:artifact/1024.brave_rod/trigger/combo/laser

--- a/Asset/data/asset/functions/artifact/1024.brave_rod/trigger/combo/laser_finish.mcfunction
+++ b/Asset/data/asset/functions/artifact/1024.brave_rod/trigger/combo/laser_finish.mcfunction
@@ -8,16 +8,19 @@
 
 # パーティクル
     # 内側
-        particle dust 0.6 0.9 1 1 ^ ^ ^ 0 0 0 1 1 force @a[distance=..30]
-        particle dust 0.6 0.9 1 1 ^ ^ ^0.5 0 0 0 1 1 force @a[distance=..30]
-        particle dust 0.6 0.9 1 1 ^ ^ ^-0.5 0 0 0 1 1 force @a[distance=..30]
+        particle dust 0.6 0.9 1 0.7 ^ ^ ^ 0 0 0 1 1 force @a[distance=..30]
+        particle dust 0.6 0.9 1 0.7 ^ ^ ^0.5 0 0 0 1 1 force @a[distance=..30]
+        particle dust 0.6 0.9 1 0.7 ^ ^ ^-0.5 0 0 0 1 1 force @a[distance=..30]
     # 外側
-        particle dust 0.3 0.9 1 0.7 ^ ^ ^ 0.07 0.07 0.07 1 1 force @a[distance=..30]
-        particle dust 0.3 0.9 1 0.7 ^ ^ ^0.5 0.07 0.07 0.07 1 1 force @a[distance=..30]
-        particle dust 0.3 0.9 1 0.7 ^ ^ ^-0.5 0.07 0.07 0.07 1 1 force @a[distance=..30]
+        particle dust 0.3 0.9 1 0.3 ^ ^ ^ 0.07 0.07 0.07 1 1 force @a[distance=..30]
+        particle dust 0.3 0.9 1 0.3 ^ ^ ^0.5 0.07 0.07 0.07 1 1 force @a[distance=..30]
+        particle dust 0.3 0.9 1 0.3 ^ ^ ^-0.5 0.07 0.07 0.07 1 1 force @a[distance=..30]
 
 # ダメージ判定
     execute positioned ~-0.5 ~-0.5 ~-0.5 as @e[type=#lib:living,tag=Enemy,tag=!Uninterferable,dx=0,sort=nearest,limit=1] run function asset:artifact/1024.brave_rod/trigger/combo/laser_damage
+
+# 後でレーザーの長さを決めるためにスコア加算
+    scoreboard players add @s Temporary 1
 
 # 再帰で前に飛ばす。ヒットしてたら移動停止
     execute if entity @s[tag=!SG.Hit,distance=..25] if block ~ ~ ~ #lib:no_collision positioned ^ ^ ^1 run function asset:artifact/1024.brave_rod/trigger/combo/laser_finish


### PR DESCRIPTION
- 確かに前までの使用音はデカかった。連射武器だからなおさら。
- 今回は音量を下げただけですが、もっと地味な音にするとかそういうのでもいいのかも。
- この際なので前から気になっていたビームの見た目を強化。ツタンカーメンやトゥルとかが使うタイプのビームになりました。