### PR TITLE
⚖ [Mob 155] 背徳の調整

### DIFF
--- a/Asset/data/asset/functions/mob/0155.immorality/register.mcfunction
+++ b/Asset/data/asset/functions/mob/0155.immorality/register.mcfunction
@@ -54,3 +54,6 @@
         data modify storage asset:mob Resist.Water set value 1.0
     # 雷倍率 (float) (オプション)
         data modify storage asset:mob Resist.Thunder set value 1.2
+
+# ダメージ
+    data modify storage asset:mob Field.Damage set value 28.0f

--- a/Asset/data/asset/functions/mob/0155.immorality/tick/.mcfunction
+++ b/Asset/data/asset/functions/mob/0155.immorality/tick/.mcfunction
@@ -11,7 +11,7 @@
     execute if entity @s[scores={General.Mob.Tick=0}] run function asset:mob/0155.immorality/tick/shot/ready
 
 # 予告
-    execute if entity @s[scores={General.Mob.Tick=0..39}] run function asset:mob/0155.immorality/tick/announce/
+    execute if entity @s[scores={General.Mob.Tick=1..39}] run function asset:mob/0155.immorality/tick/announce/
 
 # 発砲
     execute if entity @p[distance=..20] if entity @s[scores={General.Mob.Tick=40..}] anchored eyes positioned ^-0.3 ^ ^1 run function asset:mob/0155.immorality/tick/shot/interval

--- a/Asset/data/asset/functions/mob/0155.immorality/tick/.mcfunction
+++ b/Asset/data/asset/functions/mob/0155.immorality/tick/.mcfunction
@@ -10,8 +10,11 @@
 # 発砲準備で向きと位置を固定し、射撃回数を計算する
     execute if entity @s[scores={General.Mob.Tick=0}] run function asset:mob/0155.immorality/tick/shot/ready
 
+# 予告
+    execute if entity @s[scores={General.Mob.Tick=0..39}] run function asset:mob/0155.immorality/tick/announce/
+
 # 発砲
-    execute if entity @p[distance=..20] if entity @s[scores={General.Mob.Tick=20..}] anchored eyes positioned ^-0.3 ^ ^1 run function asset:mob/0155.immorality/tick/shot/interval
+    execute if entity @p[distance=..20] if entity @s[scores={General.Mob.Tick=40..}] anchored eyes positioned ^-0.3 ^ ^1 run function asset:mob/0155.immorality/tick/shot/interval
 
 # 計算した回数射撃したならリセット
 # ShotCountは5.shot、ShotMaxは3.readyで計算している

--- a/Asset/data/asset/functions/mob/0155.immorality/tick/announce/.mcfunction
+++ b/Asset/data/asset/functions/mob/0155.immorality/tick/announce/.mcfunction
@@ -1,0 +1,11 @@
+#> asset:mob/0155.immorality/tick/announce/
+#
+# 予告
+#
+# @within function asset:mob/0155.immorality/tick/
+
+# 2tick間隔で実行する
+    scoreboard players operation $Interval Temporary = @s General.Mob.Tick
+    scoreboard players operation $Interval Temporary %= $2 Const
+    execute if score $Interval Temporary matches 0 anchored eyes positioned ^-0.3 ^ ^1 run function asset:mob/0155.immorality/tick/announce/recursive_line
+    scoreboard players reset $Interval Temporary

--- a/Asset/data/asset/functions/mob/0155.immorality/tick/announce/recursive_line.mcfunction
+++ b/Asset/data/asset/functions/mob/0155.immorality/tick/announce/recursive_line.mcfunction
@@ -1,0 +1,17 @@
+#> asset:mob/0155.immorality/tick/announce/recursive_line
+#
+#
+#
+# @within function
+#   asset:mob/0155.immorality/tick/announce/
+#   asset:mob/0155.immorality/tick/announce/recursive_line
+
+# vfx
+    particle electric_spark ^ ^ ^0.0 0 0 0 0 1 normal @a
+    particle electric_spark ^ ^ ^0.5 0 0 0 0 1 normal @a
+
+# プレイヤーに接触したらreturn
+    execute positioned ~-0.5 ~-0.5 ~-0.5 if entity @p[tag=!PlayerShouldInvulnerable,dx=0] run return fail
+
+# 再帰
+    execute if entity @s[distance=..20] positioned ^ ^ ^1 run function asset:mob/0155.immorality/tick/announce/recursive_line

--- a/Asset/data/asset/functions/mob/0155.immorality/tick/shot/damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0155.immorality/tick/shot/damage.mcfunction
@@ -8,7 +8,7 @@
     particle minecraft:soul ~ ~ ~ 0 0 0 0.2 10
 
 # ダメージ
-    data modify storage api: Argument.Damage set value 28.0f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage
     data modify storage api: Argument.AttackType set value "Magic"
     data modify storage api: Argument.ElementType set value "Fire"
     data modify storage api: Argument.DeathMessage append value '[{"translate": "%1$sは%2$sに精神を破壊された","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]'

--- a/Asset/data/asset/functions/mob/0155.immorality/tick/shot/damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0155.immorality/tick/shot/damage.mcfunction
@@ -14,14 +14,14 @@
     data modify storage api: Argument.DeathMessage append value '[{"translate": "%1$sは%2$sに精神を破壊された","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]'
     data modify storage api: Argument.DeathMessage append value '[{"translate": "%1$sは%2$sに魂を撃ち抜かれた","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]'
     execute as @e[type=zombie,tag=this,distance=..25,sort=nearest,limit=1] run function api:damage/modifier
-    execute unless entity @s[gamemode=creative] run function api:damage/
+    execute if entity @s[tag=!PlayerShouldInvulnerable] run function api:damage/
     function api:damage/reset
 
 # 衰弱Lv2
     function api:global_vars/get_difficulty
     data modify storage api: Argument set value {ID:80,Duration:160}
     execute store result storage api: Argument.Stack int 2 run data get storage api: Return.Difficulty
-    function api:entity/mob/effect/give
+    execute if entity @s[tag=!PlayerShouldInvulnerable] run function api:entity/mob/effect/give
     function api:entity/mob/effect/reset
 
 # 着弾タグを消す

--- a/Asset/data/asset/functions/mob/0155.immorality/tick/shot/reset.mcfunction
+++ b/Asset/data/asset/functions/mob/0155.immorality/tick/shot/reset.mcfunction
@@ -8,7 +8,7 @@
     data modify entity @s NoAI set value 0b
 
 # 次に攻撃するタイミングをランダムにする
-    execute store result score @s General.Mob.Tick run random value 80..130
+    execute store result score @s General.Mob.Tick run random value -130..-80
 
 # リセット処理
     scoreboard players reset @s 4B.ShotCount

--- a/Asset/data/asset/functions/mob/0155.immorality/tick/shot/reset.mcfunction
+++ b/Asset/data/asset/functions/mob/0155.immorality/tick/shot/reset.mcfunction
@@ -4,32 +4,12 @@
 #
 # @within function asset:mob/0155.immorality/tick/
 
-#> Private
-# @private
-    #declare score_holder $Random
-    #declare score_holder $DivisionValue
-
 # 自身のNoAIを解除
     data modify entity @s NoAI set value 0b
 
 # 次に攻撃するタイミングをランダムにする
-# 難易度で剰余の範囲が変動する
-    function api:global_vars/get_difficulty
-    execute store result score $DivisionValue Temporary run data get storage api: Return.Difficulty 15
-    scoreboard players add $DivisionValue Temporary 1
-
-# 疑似乱数取得
-    execute store result score $Random Temporary run random value 0..65535
-# 剰余算する
-    scoreboard players operation $Random Temporary %= $DivisionValue Temporary
-# スコアセット
-    scoreboard players operation @s General.Mob.Tick = $Random Temporary
-    scoreboard players remove @s General.Mob.Tick 80
-# この段階でGeneral.Mob.Tickが0以上なら-1にする
-    execute if entity @s[scores={General.Mob.Tick=0..}] run scoreboard players set @s General.Mob.Tick -1
+    execute store result score @s General.Mob.Tick run random value 80..130
 
 # リセット処理
-    scoreboard players reset $Random Temporary
-    scoreboard players reset $DivisionValue Temporary
     scoreboard players reset @s 4B.ShotCount
     scoreboard players reset @s 4B.ShotMax

--- a/Asset/data/asset/functions/mob/0155.immorality/tick/shot/reset.mcfunction
+++ b/Asset/data/asset/functions/mob/0155.immorality/tick/shot/reset.mcfunction
@@ -8,7 +8,7 @@
     data modify entity @s NoAI set value 0b
 
 # 次に攻撃するタイミングをランダムにする
-    execute store result score @s General.Mob.Tick run random value -130..-80
+    execute store result score @s General.Mob.Tick run random value -110..-80
 
 # リセット処理
     scoreboard players reset @s 4B.ShotCount

--- a/Asset/data/asset/functions/mob/0155.immorality/tick/shot/shoot.mcfunction
+++ b/Asset/data/asset/functions/mob/0155.immorality/tick/shot/shoot.mcfunction
@@ -31,5 +31,5 @@
     execute as @a[tag=LandingTarget,distance=..25] at @s run function asset:mob/0155.immorality/tick/shot/damage
 
 # リセット
-    kill @e[type=marker,tag=SpreadMarker,limit=1]
+    kill @e[type=marker,tag=SpreadMarker,distance=..10,limit=1]
     tag @s remove Landing


### PR DESCRIPTION
・攻撃前に予告を出すように
・難易度比例で攻撃間隔が短くなる仕様を廃止