### PR TITLE
⚖ [Effect 606] 石化の解除Lvを1に

### DIFF
--- a/Asset/data/asset/functions/effect/0606.mineralization/register.mcfunction
+++ b/Asset/data/asset/functions/effect/0606.mineralization/register.mcfunction
@@ -29,7 +29,7 @@
 # 死亡時のエフェクトの処理 (default = "remove")
     # data modify storage asset:effect ProcessOnDied set value
 # 消すのに必要なレベル (int) (default = 1)
-    data modify storage asset:effect RequireClearLv set value 2
+    data modify storage asset:effect RequireClearLv set value 1
 # エフェクトをUIに表示するか (boolean) (default = true)
     # data modify storage asset:effect Visible set value
 # エフェクトのスタックををUIに表示するか (boolean) (default = true)


### PR DESCRIPTION
Fix #1479
ぶっちゃけ結構悩みつつ、効果時間がそんな長いわけでもないんだし、かといってこのデバフを長くすると最強になってしまうので解除Lv1かな～～～って判断