### PR TITLE
[Mob 410] 黒龍Issue対応

### DIFF
--- a/Asset/data/asset/functions/mob/0410.heiloang/init/locator.mcfunction
+++ b/Asset/data/asset/functions/mob/0410.heiloang/init/locator.mcfunction
@@ -5,7 +5,7 @@
 # @within asset:mob/0410.heiloang/init/animated_java
 
 # Locatorに以下処理を実行する
-    data merge entity @s {CustomName:'{"text":"『黒龍』","italic":false}',Silent:1b,NoAI:1b,DeathLootTable:"minecraft:empty",PersistenceRequired :1b,Attributes:[{Name:"generic.max_health",Base:1024d}]}
+    data merge entity @s {CustomName:'{"text":"『黒龍』","italic":false}',Silent:1b,NoAI:1b,DeathLootTable:"minecraft:empty",PersistenceRequired :1b,Attributes:[{Name:"generic.max_health",Base:1024d}],ArmorDropChances:[0.000f,0.000f,0.000f,0.000f]}
     scoreboard players operation @s ForwardTargetMobUUID = @e[type=slime,tag=BE.EntityRoot,limit=1] MobUUID
     tag @s add Enemy
     tag @s add Enemy.Boss

--- a/Asset/data/asset/functions/mob/0410.heiloang/tick/debug/interrupt.mcfunction
+++ b/Asset/data/asset/functions/mob/0410.heiloang/tick/debug/interrupt.mcfunction
@@ -21,5 +21,5 @@
 # イベント実行
     scoreboard players set @s BE.EventTimer 0
     # tag @s add BE.Skill.Ter.Purg.Start
-    tag @s add BE.Skill.Ehd
+    tag @s add BE.Skill.HeilDisaster
     scoreboard players set @s BE.Pb.Count 5

--- a/Asset/data/asset/functions/mob/0410.heiloang/tick/event/final_flare/damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0410.heiloang/tick/event/final_flare/damage.mcfunction
@@ -23,7 +23,7 @@
     # 計算
         execute store result storage api: Argument.Damage double 0.0001 run scoreboard players operation $FlareDamage Temporary *= $MaxHealth Temporary
         # 即死ラインを超えている場合はダメージを9999に固定
-            execute if score $FlareDamage Temporary matches 100.. run data modify storage api: Argument.Damage set value 9999.0
+            execute if score $FlareDamage Temporary matches 100.. run data modify storage api: Argument.Damage set value 9999.9
     # 終了
         scoreboard players reset $ChargeCount Temporary
         scoreboard players reset $FlareDamage Temporary

--- a/Asset/data/asset/functions/mob/0410.heiloang/tick/event/final_flare/damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0410.heiloang/tick/event/final_flare/damage.mcfunction
@@ -12,16 +12,18 @@
         execute store result score $MaxHealth Temporary run data get storage api: Return.MaxHealth 100
     # ChargeCount（残った眷属の数）に応じてダメージを増加
     # 難易度によって倍率は変わる
-    # 基本値50%、Normal：最大70%、Hard：最大90%、Blessless：最大120%
-        execute if predicate api:global_vars/difficulty/1_normal run scoreboard players set $FlareDamage Temporary 10
-        execute if predicate api:global_vars/difficulty/2_hard run scoreboard players set $FlareDamage Temporary 20
-        execute if predicate api:global_vars/difficulty/min/3_blessless run scoreboard players set $FlareDamage Temporary 35
+    # 基本値50%、Normal：+20%、Hard：+40%、Blessless：+100%
+        execute if predicate api:global_vars/difficulty/1_normal run scoreboard players set $FlareDamage Temporary 20
+        execute if predicate api:global_vars/difficulty/2_hard run scoreboard players set $FlareDamage Temporary 40
+        execute if predicate api:global_vars/difficulty/min/3_blessless run scoreboard players set $FlareDamage Temporary 100
         # ChargeCountの初期値は-1のため、一時的に1加算する
             scoreboard players add $ChargeCount Temporary 1
             scoreboard players operation $FlareDamage Temporary *= $ChargeCount Temporary
         scoreboard players add $FlareDamage Temporary 50
     # 計算
         execute store result storage api: Argument.Damage double 0.0001 run scoreboard players operation $FlareDamage Temporary *= $MaxHealth Temporary
+        # 即死ラインを超えている場合はダメージを9999に固定
+            execute if score $FlareDamage Temporary matches 100.. run data modify storage api: Argument.Damage set value 9999.0
     # 終了
         scoreboard players reset $ChargeCount Temporary
         scoreboard players reset $FlareDamage Temporary
@@ -29,7 +31,7 @@
     data modify storage api: Argument.AttackType set value "Magic"
     data modify storage api: Argument.ElementType set value "Fire"
     data modify storage api: Argument.FixedDamage set value 1b
-    data modify storage api: Argument.DeathMessage set value ['[{"translate": "%1$sは 黒龍に滅せられた","with":[{"selector":"@s"}]}]']
+    data modify storage api: Argument.DeathMessage set value ['[{"translate": "%1$sは%2$sに滅せられた","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]']
     data modify storage api: Argument.Metadata set value "FinalFlare"
     execute store result storage api: Argument.MobUUID int 1 run scoreboard players get @e[type=slime,tag=BE.EntityRoot,limit=1] MobUUID
     function api:damage/modifier_manual

--- a/Asset/data/asset/functions/mob/0410.heiloang/tick/event/heil_disaster/.mcfunction
+++ b/Asset/data/asset/functions/mob/0410.heiloang/tick/event/heil_disaster/.mcfunction
@@ -52,6 +52,17 @@
         execute if score @s BE.EventTimer matches 259 at @e[type=marker,tag=BE.CenterPosition] rotated ~-90 ~ positioned ^ ^ ^19.5 rotated ~180 ~ run function asset:mob/0410.heiloang/tick/event/sweep/prediction
     # 攻撃
         execute if score @s BE.EventTimer matches 261..319 as @e[type=item_display,tag=BE.ModelRoot,sort=nearest,limit=1] at @s on passengers if entity @s[tag=aj.global.data] run function asset:mob/0410.heiloang/tick/event/sweep/get_attack_position.m with entity @s data.locators.locator_head
+        # ヒット判定、ダメージ
+            execute if score @s BE.EventTimer matches 299 at @e[type=marker,tag=BE.CenterPosition] positioned ^18 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 300 at @e[type=marker,tag=BE.CenterPosition] positioned ^14 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 301 at @e[type=marker,tag=BE.CenterPosition] positioned ^10 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 302 at @e[type=marker,tag=BE.CenterPosition] positioned ^6 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 303 at @e[type=marker,tag=BE.CenterPosition] positioned ^2 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 304 at @e[type=marker,tag=BE.CenterPosition] positioned ^-2 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 305 at @e[type=marker,tag=BE.CenterPosition] positioned ^-6 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 306 at @e[type=marker,tag=BE.CenterPosition] positioned ^-10 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 307 at @e[type=marker,tag=BE.CenterPosition] positioned ^-14 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 308 at @e[type=marker,tag=BE.CenterPosition] positioned ^-18 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
     # 演出
         execute if score @s BE.EventTimer matches 259 as @e[type=item_display,tag=BE.ModelRoot,sort=nearest,limit=1] at @s on passengers if entity @s[tag=aj.global.data] run function asset:mob/0410.heiloang/tick/event/sweep/text_start with entity @s data.locators.beam_start
         execute if score @s BE.EventTimer matches 259..319 as @e[type=item_display,tag=BE.ModelRoot,sort=nearest,limit=1] at @s on passengers if entity @s[tag=aj.global.data] run function asset:mob/0410.heiloang/tick/event/sweep/text with entity @s data.locators.beam_start

--- a/Asset/data/asset/functions/mob/0410.heiloang/tick/event/heil_disaster/hard.mcfunction
+++ b/Asset/data/asset/functions/mob/0410.heiloang/tick/event/heil_disaster/hard.mcfunction
@@ -53,6 +53,17 @@
         execute if score @s BE.EventTimer matches 259 at @e[type=marker,tag=BE.CenterPosition] rotated ~-90 ~ positioned ^ ^ ^19.5 rotated ~180 ~ run function asset:mob/0410.heiloang/tick/event/sweep/prediction
     # 攻撃
         execute if score @s BE.EventTimer matches 261..319 as @e[type=item_display,tag=BE.ModelRoot,sort=nearest,limit=1] at @s on passengers if entity @s[tag=aj.global.data] run function asset:mob/0410.heiloang/tick/event/sweep/get_attack_position.m with entity @s data.locators.locator_head
+        # ヒット判定、ダメージ
+            execute if score @s BE.EventTimer matches 299 at @e[type=marker,tag=BE.CenterPosition] positioned ^18 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 300 at @e[type=marker,tag=BE.CenterPosition] positioned ^14 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 301 at @e[type=marker,tag=BE.CenterPosition] positioned ^10 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 302 at @e[type=marker,tag=BE.CenterPosition] positioned ^6 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 303 at @e[type=marker,tag=BE.CenterPosition] positioned ^2 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 304 at @e[type=marker,tag=BE.CenterPosition] positioned ^-2 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 305 at @e[type=marker,tag=BE.CenterPosition] positioned ^-6 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 306 at @e[type=marker,tag=BE.CenterPosition] positioned ^-10 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 307 at @e[type=marker,tag=BE.CenterPosition] positioned ^-14 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 308 at @e[type=marker,tag=BE.CenterPosition] positioned ^-18 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
     # 演出
         execute if score @s BE.EventTimer matches 259 as @e[type=item_display,tag=BE.ModelRoot,sort=nearest,limit=1] at @s on passengers if entity @s[tag=aj.global.data] run function asset:mob/0410.heiloang/tick/event/sweep/text_start with entity @s data.locators.beam_start
         execute if score @s BE.EventTimer matches 259..319 as @e[type=item_display,tag=BE.ModelRoot,sort=nearest,limit=1] at @s on passengers if entity @s[tag=aj.global.data] run function asset:mob/0410.heiloang/tick/event/sweep/text with entity @s data.locators.beam_start
@@ -69,6 +80,17 @@
             execute if score @s BE.EventTimer matches 319 at @e[type=marker,tag=BE.CenterPosition] rotated ~90 ~ positioned ^ ^ ^19.5 rotated ~180 ~ run function asset:mob/0410.heiloang/tick/event/sweep/prediction
         # 攻撃
             execute if score @s BE.EventTimer matches 322..376 as @e[type=item_display,tag=BE.ModelRoot,sort=nearest,limit=1] at @s on passengers if entity @s[tag=aj.global.data] run function asset:mob/0410.heiloang/tick/event/sweep/get_attack_position.m with entity @s data.locators.locator_head
+        # ヒット判定、ダメージ
+            execute if score @s BE.EventTimer matches 356 at @e[type=marker,tag=BE.CenterPosition] positioned ^-18 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 357 at @e[type=marker,tag=BE.CenterPosition] positioned ^-14 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 358 at @e[type=marker,tag=BE.CenterPosition] positioned ^-10 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 359 at @e[type=marker,tag=BE.CenterPosition] positioned ^-6 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 360 at @e[type=marker,tag=BE.CenterPosition] positioned ^-2 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 361 at @e[type=marker,tag=BE.CenterPosition] positioned ^2 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 362 at @e[type=marker,tag=BE.CenterPosition] positioned ^6 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 363 at @e[type=marker,tag=BE.CenterPosition] positioned ^10 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 364 at @e[type=marker,tag=BE.CenterPosition] positioned ^14 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 365 at @e[type=marker,tag=BE.CenterPosition] positioned ^18 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
         # 演出
             execute if score @s BE.EventTimer matches 311 as @e[type=item_display,tag=BE.ModelRoot,sort=nearest,limit=1] at @s on passengers if entity @s[tag=aj.global.data] run function asset:mob/0410.heiloang/tick/event/sweep/text_start with entity @s data.locators.beam_start
             execute if score @s BE.EventTimer matches 311..376 as @e[type=item_display,tag=BE.ModelRoot,sort=nearest,limit=1] at @s on passengers if entity @s[tag=aj.global.data] run function asset:mob/0410.heiloang/tick/event/sweep/text with entity @s data.locators.beam_start

--- a/Asset/data/asset/functions/mob/0410.heiloang/tick/event/sweep/.mcfunction
+++ b/Asset/data/asset/functions/mob/0410.heiloang/tick/event/sweep/.mcfunction
@@ -14,6 +14,17 @@
         execute if score @s BE.EventTimer matches 5 at @e[type=marker,tag=BE.CenterPosition] rotated ~-90 ~ positioned ^ ^ ^19.5 rotated ~180 ~ run function asset:mob/0410.heiloang/tick/event/sweep/prediction
     # 攻撃
         execute if score @s BE.EventTimer matches 47..104 as @e[type=item_display,tag=BE.ModelRoot,sort=nearest,limit=1] at @s on passengers if entity @s[tag=aj.global.data] run function asset:mob/0410.heiloang/tick/event/sweep/get_attack_position.m with entity @s data.locators.locator_head
+        # ヒット判定、ダメージ
+            execute if score @s BE.EventTimer matches 85 at @e[type=marker,tag=BE.CenterPosition] positioned ^18 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 86 at @e[type=marker,tag=BE.CenterPosition] positioned ^14 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 87 at @e[type=marker,tag=BE.CenterPosition] positioned ^10 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 88 at @e[type=marker,tag=BE.CenterPosition] positioned ^6 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 89 at @e[type=marker,tag=BE.CenterPosition] positioned ^2 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 90 at @e[type=marker,tag=BE.CenterPosition] positioned ^-2 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 91 at @e[type=marker,tag=BE.CenterPosition] positioned ^-6 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 92 at @e[type=marker,tag=BE.CenterPosition] positioned ^-10 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 93 at @e[type=marker,tag=BE.CenterPosition] positioned ^-14 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+            execute if score @s BE.EventTimer matches 94 at @e[type=marker,tag=BE.CenterPosition] positioned ^-18 ^1 ^ run function asset:mob/0410.heiloang/tick/event/sweep/attack_damage
     # 演出
         execute if score @s BE.EventTimer matches 45 as @e[type=item_display,tag=BE.ModelRoot,sort=nearest,limit=1] at @s on passengers if entity @s[tag=aj.global.data] run function asset:mob/0410.heiloang/tick/event/sweep/text_start with entity @s data.locators.beam_start
         execute if score @s BE.EventTimer matches 45..105 as @e[type=item_display,tag=BE.ModelRoot,sort=nearest,limit=1] at @s on passengers if entity @s[tag=aj.global.data] run function asset:mob/0410.heiloang/tick/event/sweep/text with entity @s data.locators.beam_start

--- a/Asset/data/asset/functions/mob/0410.heiloang/tick/event/sweep/attack.mcfunction
+++ b/Asset/data/asset/functions/mob/0410.heiloang/tick/event/sweep/attack.mcfunction
@@ -4,26 +4,26 @@
 #
 # @within function asset:mob/0410.heiloang/tick/event/sweep/attack
 
-# 演出 + ヒット判定
+# 演出
     particle explosion ~ ~ ~ 1 1 1 0 1 force
     playsound item.firecharge.use hostile @a ~ ~ ~ 3 0.5
     scoreboard players set @s BE.Dummy 30
     function asset:mob/0410.heiloang/tick/event/sweep/attack_loop
     scoreboard players reset @s BE.Dummy
 
-# 一定tickごとにダメージ
-    scoreboard players operation @s BE.Dummy = @s BE.EventTimer
-    scoreboard players operation @s BE.Dummy %= $7 Const
-    execute if score @s BE.Dummy matches 1.. run return run scoreboard players reset @s BE.Dummy
+# # 一定tickごとにダメージ
+#     scoreboard players operation @s BE.Dummy = @s BE.EventTimer
+#     scoreboard players operation @s BE.Dummy %= $7 Const
+#     execute if score @s BE.Dummy matches 1.. run return run scoreboard players reset @s BE.Dummy
 
-# ダメージ
-    data modify storage api: Argument.Damage set from storage asset:context this.Damage.Sweep
-    data modify storage api: Argument.AttackType set value "Magic"
-    data modify storage api: Argument.ElementType set value "Fire"
-    function api:damage/modifier
-    execute as @a[tag=BE.Temp.HitFlame] run function api:damage/
-    function api:damage/reset
+# # ダメージ
+#     data modify storage api: Argument.Damage set from storage asset:context this.Damage.Sweep
+#     data modify storage api: Argument.AttackType set value "Magic"
+#     data modify storage api: Argument.ElementType set value "Fire"
+#     function api:damage/modifier
+#     execute as @a[tag=BE.Temp.HitFlame] run function api:damage/
+#     function api:damage/reset
 
-# 終了
-    scoreboard players reset @s BE.Dummy
-    tag @a remove BE.Temp.HitFlame
+# # 終了
+#     scoreboard players reset @s BE.Dummy
+#     tag @a remove BE.Temp.HitFlame

--- a/Asset/data/asset/functions/mob/0410.heiloang/tick/event/sweep/attack_damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0410.heiloang/tick/event/sweep/attack_damage.mcfunction
@@ -1,0 +1,35 @@
+#> asset:mob/0410.heiloang/tick/event/sweep/attack_damage
+#
+# なぎはらい火炎放射
+#
+# @within
+#         function asset:mob/0410.heiloang/tick/event/sweep/
+#         function asset:mob/0410.heiloang/tick/event/heil_disaster/
+#         function asset:mob/0410.heiloang/tick/event/heil_disaster/hard
+
+# ヒット判定
+    tag @a[tag=DXYZ] remove DXYZ
+    data modify storage lib: args.dx set value 2
+    data modify storage lib: args.dy set value 3
+    data modify storage lib: args.dz set value 20
+    data modify storage lib: args.selector set value "@a[tag=!PlayerShouldInvulnerable,distance=..60]"
+    execute positioned ^ ^ ^ run function lib:rotatable_dxyz/m with storage lib: args
+
+# ダメージ
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage.Sweep
+    data modify storage api: Argument.AttackType set value "Magic"
+    data modify storage api: Argument.ElementType set value "Fire"
+    function api:damage/modifier
+    execute as @a[tag=DXYZ] run function api:damage/
+    function api:damage/reset
+
+ # デバッグ用、攻撃範囲の可視化
+    # data modify storage api: Argument.ID set value 2113
+    # data modify storage api: Argument.FieldOverride.Color set value 16761175
+    # data modify storage api: Argument.FieldOverride.Scale set value [4f,40f]
+    # data modify storage api: Argument.FieldOverride.Interpolation set value 1
+    # data modify storage api: Argument.FieldOverride.Tick set value 20
+    # execute positioned ^ ^-0.8 ^-20 run function api:object/summon
+
+# 終了
+    tag @a remove DXYZ

--- a/Asset/data/asset/functions/mob/0410.heiloang/tick/event/sweep/attack_damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0410.heiloang/tick/event/sweep/attack_damage.mcfunction
@@ -10,7 +10,7 @@
 # ヒット判定
     tag @a[tag=DXYZ] remove DXYZ
     data modify storage lib: args.dx set value 2
-    data modify storage lib: args.dy set value 3
+    data modify storage lib: args.dy set value 2
     data modify storage lib: args.dz set value 20
     data modify storage lib: args.selector set value "@a[tag=!PlayerShouldInvulnerable,distance=..60]"
     execute positioned ^ ^ ^ run function lib:rotatable_dxyz/m with storage lib: args

--- a/Asset/data/asset/functions/mob/0410.heiloang/tick/event/sweep/attack_loop.mcfunction
+++ b/Asset/data/asset/functions/mob/0410.heiloang/tick/event/sweep/attack_loop.mcfunction
@@ -12,7 +12,7 @@
     execute if predicate lib:random_pass_per/30 run particle large_smoke ~ ~ ~ 0.5 0.5 0.5 0.1 1 force
     execute if predicate lib:random_pass_per/20 run particle lava ~ ~ ~ 1 1 1 0.1 1 force
     execute if predicate lib:random_pass_per/5 run particle explosion ~ ~ ~ 1 1 1 0.1 1 force
-    execute positioned ^ ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..2.4] add BE.Temp.HitFlame
-    execute positioned ^-2 ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..2.4] add BE.Temp.HitFlame
-    execute positioned ^2 ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..2.4] add BE.Temp.HitFlame
+    # execute positioned ^ ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..2.4] add BE.Temp.HitFlame
+    # execute positioned ^-2 ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..2.4] add BE.Temp.HitFlame
+    # execute positioned ^2 ^ ^ run tag @a[tag=!PlayerShouldInvulnerable,distance=..2.4] add BE.Temp.HitFlame
     execute if score @s BE.Dummy matches 1.. positioned ^ ^ ^1.5 run function asset:mob/0410.heiloang/tick/event/sweep/attack_loop

--- a/Asset/data/asset/functions/mob/0411.behemoth/init/locator.mcfunction
+++ b/Asset/data/asset/functions/mob/0411.behemoth/init/locator.mcfunction
@@ -14,4 +14,7 @@
     tag @s add ProcessCommonTag
 
 # 常に耐性付与
-    effect give @s resistance infinite 2 true
+    data modify storage api: Argument set value {ID:150,Duration:2147483647,Stack:2}
+    function api:entity/mob/effect/give
+    function api:entity/mob/effect/reset
+    # effect give @s resistance infinite 2 true

--- a/Asset/data/asset/functions/mob/0411.behemoth/init/locator.mcfunction
+++ b/Asset/data/asset/functions/mob/0411.behemoth/init/locator.mcfunction
@@ -5,14 +5,13 @@
 # @within asset:mob/0411.behemoth/init/animated_java
 
 # Locatorに以下処理を実行する
-    data merge entity @s {CustomName:'{"text":"『焔竜』","color":"#8AB9FF","italic":false}',Silent:1b,NoAI:1b,DeathLootTable:"minecraft:empty",PersistenceRequired :1b,Attributes:[{Name:"generic.max_health",Base:1024d}]}
+    data merge entity @s {CustomName:'{"text":"『焔竜』","color":"#8AB9FF","italic":false}',Silent:1b,NoAI:1b,DeathLootTable:"minecraft:empty",PersistenceRequired :1b,Attributes:[{Name:"generic.max_health",Base:1024d}],ArmorDropChances:[0.000f,0.000f,0.000f,0.000f]}
     scoreboard players operation @s ForwardTargetMobUUID = @e[type=slime,tag=BF.EntityRoot,limit=1] MobUUID
     tag @s add Enemy
     tag @s add Enemy.Boss
     tag @s add ExtendedCollision
     tag @s add AlwaysInvisible
     tag @s add ProcessCommonTag
-    # effect give @s instant_health infinite 0 true
 
 # 常に耐性付与
     effect give @s resistance infinite 2 true

--- a/Asset/data/asset/functions/mob/0411.behemoth/tick/event/offering_end/.mcfunction
+++ b/Asset/data/asset/functions/mob/0411.behemoth/tick/event/offering_end/.mcfunction
@@ -1,6 +1,6 @@
 #> asset:mob/0411.behemoth/tick/event/offering_end/
 #
-# ブレイジングエンド
+# ソウルオファリング
 #
 # @within asset:mob/0411.behemoth/tick/event/
 

--- a/Asset/data/asset/functions/mob/0411.behemoth/tick/event/terzetto_purgatorio/attack.m.mcfunction
+++ b/Asset/data/asset/functions/mob/0411.behemoth/tick/event/terzetto_purgatorio/attack.m.mcfunction
@@ -21,7 +21,7 @@
     data modify storage api: Argument.ElementType set value "Fire"
     execute store result storage api: Argument.MobUUID int 1 run scoreboard players get @e[type=item_display,tag=BF.EntityRoot,limit=1] MobUUID
     function api:damage/modifier_manual
-    execute as @a[tag=BF.Temp.AttackHit] run function api:damage/
+    execute as @a[tag=BF.Temp.AttackHit,distance=..80] run function api:damage/
     function api:damage/reset
     tag @a remove BF.FlareTarget
     tag @a remove BF.Temp.AttackHit

--- a/Asset/data/asset/functions/mob/0411.behemoth/tick/util/end_armor_locator.mcfunction
+++ b/Asset/data/asset/functions/mob/0411.behemoth/tick/util/end_armor_locator.mcfunction
@@ -4,5 +4,7 @@
 #
 # @within asset:mob/0411.behemoth/tick/util/end_armor
 
-# 無敵化解除
-    effect clear @s resistance
+# エフェクト消去
+    data modify storage api: Argument.ID set value 150
+    function api:entity/mob/effect/remove/from_id
+    function api:entity/mob/effect/reset

--- a/Asset/data/asset/functions/mob/0412.tiamat/init/locator.mcfunction
+++ b/Asset/data/asset/functions/mob/0412.tiamat/init/locator.mcfunction
@@ -12,7 +12,9 @@
     tag @s add ExtendedCollision
     tag @s add AlwaysInvisible
     tag @s add ProcessCommonTag
-    # effect give @s instant_health infinite 0 true
 
-# # 常に耐性付与
-#     effect give @s resistance infinite 2 true
+# 常に耐性付与
+    data modify storage api: Argument set value {ID:150,Duration:2147483647,Stack:2}
+    function api:entity/mob/effect/give
+    function api:entity/mob/effect/reset
+    # effect give @s resistance infinite 2 true

--- a/Asset/data/asset/functions/mob/0412.tiamat/init/locator.mcfunction
+++ b/Asset/data/asset/functions/mob/0412.tiamat/init/locator.mcfunction
@@ -5,7 +5,7 @@
 # @within asset:mob/0412.tiamat/init/animated_java
 
 # Locatorに以下処理を実行する
-    data merge entity @s {CustomName:'{"text":"『闇竜』","color":"#CB8FFF","italic":false}',Silent:1b,NoAI:1b,DeathLootTable:"minecraft:empty",PersistenceRequired :1b,Attributes:[{Name:"generic.max_health",Base:1024d}]}
+    data merge entity @s {CustomName:'{"text":"『闇竜』","color":"#CB8FFF","italic":false}',Silent:1b,NoAI:1b,DeathLootTable:"minecraft:empty",PersistenceRequired :1b,Attributes:[{Name:"generic.max_health",Base:1024d}],ArmorDropChances:[0.000f,0.000f,0.000f,0.000f]}
     scoreboard players operation @s ForwardTargetMobUUID = @e[type=slime,tag=BG.EntityRoot,limit=1] MobUUID
     tag @s add Enemy
     tag @s add Enemy.Boss
@@ -14,5 +14,5 @@
     tag @s add ProcessCommonTag
     # effect give @s instant_health infinite 0 true
 
-# 常に耐性付与
-    effect give @s resistance infinite 2 true
+# # 常に耐性付与
+#     effect give @s resistance infinite 2 true

--- a/Asset/data/asset/functions/mob/0412.tiamat/tick/event/offering_end/.mcfunction
+++ b/Asset/data/asset/functions/mob/0412.tiamat/tick/event/offering_end/.mcfunction
@@ -1,6 +1,6 @@
 #> asset:mob/0412.tiamat/tick/event/offering_end/
 #
-# フリージングエンド
+# ソウルオファリング
 #
 # @within asset:mob/0412.tiamat/tick/event/
 
@@ -19,7 +19,7 @@
         execute if score @s BG.EventTimer matches 43 run particle explosion ~ ~1 ~ 2 0 2 0 20 force
         execute if score @s BG.EventTimer matches 66 run playsound entity.ender_dragon.flap hostile @a ~ ~ ~ 3 0.7
 
-# フリージングエンド
+# ソウルオファリング
     # 詠唱
         execute if score @s BG.EventTimer matches 80 as @e[type=item_display,tag=BG.ModelRoot,sort=nearest,limit=1] run function asset:mob/0412.tiamat/tick/animated_java/play/3_3_casting_land
     # アニメーション再生

--- a/Asset/data/asset/functions/mob/0412.tiamat/tick/util/end_armor_locator.mcfunction
+++ b/Asset/data/asset/functions/mob/0412.tiamat/tick/util/end_armor_locator.mcfunction
@@ -4,5 +4,7 @@
 #
 # @within asset:mob/0412.tiamat/tick/util/end_armor
 
-# 無敵化解除
-    effect clear @s resistance
+# エフェクト消去
+    data modify storage api: Argument.ID set value 150
+    function api:entity/mob/effect/remove/from_id
+    function api:entity/mob/effect/reset

--- a/Asset/data/asset/functions/object/2127.heiloang_ice_vfx/init/.mcfunction
+++ b/Asset/data/asset/functions/object/2127.heiloang_ice_vfx/init/.mcfunction
@@ -11,7 +11,7 @@
     execute if predicate lib:random_pass_per/30 at @s run tp @s ~ ~ ~ ~30 ~
 
 # サブ召喚
-    summon item_display ~ ~ ~ {Tags:["2127.Append","BE.Object"],teleport_duration:3,interpolation_duration:3,transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,-1f,0f],scale:[0f,0f,0f]},item:{id:"minecraft:stick",Count:1b,tag:{CustomModelData:20453}}}
+    summon item_display ~ ~ ~ {Tags:["2127.Append","BE.Object"],teleport_duration:3,interpolation_duration:3,transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,-1f,0f],scale:[0f,0f,0f]},item:{id:"minecraft:stick",Count:1b,tag:{CustomModelData:20453}},brightness:{sky:15,block:15}}
     execute at @s as @e[type=item_display,tag=2127.Append,sort=nearest,limit=1] run tp @s ~ ~ ~ ~45 ~
     ride @e[type=item_display,tag=2127.Append,sort=nearest,limit=1] mount @s
 

--- a/Asset/data/asset/functions/object/2127.heiloang_ice_vfx/summon/.mcfunction
+++ b/Asset/data/asset/functions/object/2127.heiloang_ice_vfx/summon/.mcfunction
@@ -5,4 +5,4 @@
 # @within asset:object/alias/2127/summon
 
 # 元となるEntityを召喚する
-    summon item_display ~ ~ ~ {Tags:["ObjectInit","BE.Object"],teleport_duration:3,interpolation_duration:3,transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,-1f,0f],scale:[0f,0f,0f]},item:{id:"minecraft:stick",Count:1b,tag:{CustomModelData:20452}}}
+    summon item_display ~ ~ ~ {Tags:["ObjectInit","BE.Object"],teleport_duration:3,interpolation_duration:3,transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,-1f,0f],scale:[0f,0f,0f]},item:{id:"minecraft:stick",Count:1b,tag:{CustomModelData:20452}},brightness:{sky:15,block:15}}

--- a/Asset/data/asset/functions/object/2175.tiamat_ice_vfx/init/.mcfunction
+++ b/Asset/data/asset/functions/object/2175.tiamat_ice_vfx/init/.mcfunction
@@ -11,7 +11,7 @@
     execute if predicate lib:random_pass_per/30 at @s run tp @s ~ ~ ~ ~30 ~
 
 # サブ召喚
-    summon item_display ~ ~ ~ {Tags:["2175.Append"],teleport_duration:3,interpolation_duration:3,transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,-1f,0f],scale:[0f,0f,0f]},item:{id:"minecraft:stick",Count:1b,tag:{CustomModelData:20478}}}
+    summon item_display ~ ~ ~ {Tags:["2175.Append"],teleport_duration:3,interpolation_duration:3,transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,-1f,0f],scale:[0f,0f,0f]},item:{id:"minecraft:stick",Count:1b,tag:{CustomModelData:20478}},brightness:{sky:15,block:15}}
     execute at @s as @e[type=item_display,tag=2175.Append,sort=nearest,limit=1] run tp @s ~ ~ ~ ~45 ~
     ride @e[type=item_display,tag=2175.Append,sort=nearest,limit=1] mount @s
 

--- a/Asset/data/asset/functions/object/2175.tiamat_ice_vfx/summon/.mcfunction
+++ b/Asset/data/asset/functions/object/2175.tiamat_ice_vfx/summon/.mcfunction
@@ -5,4 +5,4 @@
 # @within asset:object/alias/2175/summon
 
 # 元となるEntityを召喚する
-    summon item_display ~ ~ ~ {Tags:["ObjectInit","BE.Object"],interpolation_duration:3,transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,-1f,0f],scale:[0f,0f,0f]},item:{id:"minecraft:stick",Count:1b,tag:{CustomModelData:20477}}}
+    summon item_display ~ ~ ~ {Tags:["ObjectInit","BE.Object"],interpolation_duration:3,transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,-1f,0f],scale:[0f,0f,0f]},item:{id:"minecraft:stick",Count:1b,tag:{CustomModelData:20477}},brightness:{sky:15,block:15}}

--- a/Asset/data/asset/functions/object/2182.heiloang_thunderball/tick/damage.mcfunction
+++ b/Asset/data/asset/functions/object/2182.heiloang_thunderball/tick/damage.mcfunction
@@ -12,6 +12,9 @@
     execute at @p[tag=2182.TargetPlayer] if entity @e[type=item_display,tag=2180.Pillar,distance=..4] run tag @s add 2182.Hit
     execute if entity @s[tag=2182.Hit] at @p[tag=2182.TargetPlayer] run tag @e[type=item_display,tag=2180.Pillar,sort=nearest,limit=1] add 2182.Hit
 
+# プレイヤーが一定範囲内に居ない場合、そのまま消去
+    execute unless entity @p[tag=2182.TargetPlayer,distance=..80] run function asset:object/2182.heiloang_thunderball/tick/kill
+
 # ダメージ
     data modify storage api: Argument.Damage set from storage asset:context this.Damage
     data modify storage api: Argument.AttackType set value "Magic"
@@ -28,7 +31,4 @@
     execute if entity @s[tag=!2182.Hit] positioned as @p[tag=2182.TargetPlayer] run function api:object/summon
 
 # 終了
-    execute if entity @s[tag=2182.Hit] run tag @e[type=item_display,tag=2180.Pillar,tag=2182.Hit] add 2180.Pillar.Thunder
-    execute if entity @s[tag=2182.Hit] run tag @e[type=item_display,tag=2180.Pillar,tag=2182.Hit] remove 2182.Hit
-    execute on passengers run kill @s
-    kill @s
+    function asset:object/2182.heiloang_thunderball/tick/kill

--- a/Asset/data/asset/functions/object/2182.heiloang_thunderball/tick/kill.mcfunction
+++ b/Asset/data/asset/functions/object/2182.heiloang_thunderball/tick/kill.mcfunction
@@ -1,0 +1,11 @@
+#> asset:object/2182.heiloang_thunderball/tick/kill
+#
+# Objectのtick時の処理
+#
+# @within asset:object/2182.heiloang_thunderball/tick/damage
+
+# 消去
+    execute if entity @s[tag=2182.Hit] run tag @e[type=item_display,tag=2180.Pillar,tag=2182.Hit] add 2180.Pillar.Thunder
+    execute if entity @s[tag=2182.Hit] run tag @e[type=item_display,tag=2180.Pillar,tag=2182.Hit] remove 2182.Hit
+    execute on passengers run kill @s
+    kill @s


### PR DESCRIPTION
### 修正内容
- 当たり判定を RotatedDX に変更し、厳密化
    - Fix #1555
- Hard, Blesslessでの即死判定の厳密化
- および、ダメージが 100% を超えた場合は 9999.0 固定になるよう変更
    - Fix #1544
- デスログに%2$sを使うよう修正
    - Fix #1505
- 黒龍のロックオン雷、焔竜のロックオンフレアブレスのダメージ判定にdistanceを追加
    - Fix #1491
- ArmorDropChancesを0に変更
    - Fix #1412

### 未対応
- 以下については、召喚位置を基準にしているので埋まることは普通無い。無法と同じく、実環境で召喚位置が上下にずれる問題の影響かもしれない
- 暫定策として、item_displayのbrightnessを15に固定。夜でも光り輝いてしまうけど、雷なども光っているので問題ない気はする
    - Fix #1438