### PR TITLE
[Mob 338] 双子 Issue対応

### DIFF
--- a/Asset/data/asset/functions/mob/0338.corundum_twins/0.load.mcfunction
+++ b/Asset/data/asset/functions/mob/0338.corundum_twins/0.load.mcfunction
@@ -11,3 +11,4 @@
     scoreboard objectives add 9E.SkillTimer dummy
     scoreboard objectives add 9E.ActionCount dummy
     scoreboard objectives add 9E.ForceCounterCount dummy
+    scoreboard objectives add 9E.IdleTimer dummy

--- a/Asset/data/asset/functions/mob/0338.corundum_twins/app/call_from_twins/5.idle_timer.mcfunction
+++ b/Asset/data/asset/functions/mob/0338.corundum_twins/app/call_from_twins/5.idle_timer.mcfunction
@@ -1,0 +1,10 @@
+#> asset:mob/0338.corundum_twins/app/call_from_twins/5.idle_timer
+#
+# 双子が暇してる時に呼び出される処理
+#
+# @within
+#    function asset:mob/0339.twins_sapphiel/tick/app/skill/event_handler/02_hg_idle/1.main
+#    function asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/02_kt_idle/1.main
+
+# スコア増加
+    scoreboard players add @s 9E.IdleTimer 1

--- a/Asset/data/asset/functions/mob/0338.corundum_twins/init/app/2.summon_twins.mcfunction
+++ b/Asset/data/asset/functions/mob/0338.corundum_twins/init/app/2.summon_twins.mcfunction
@@ -6,9 +6,9 @@
 
 # 双子を召喚
     data modify storage api: Argument.ID set value 339
-    execute positioned ~-0.7 ~100.5 ~ rotated ~-6 ~ run function api:mob/summon
+    execute positioned ~-0.7 ~101.5 ~2 rotated ~-6 ~ run function api:mob/summon
     data modify storage api: Argument.ID set value 340
-    execute positioned ~0.7 ~100.5 ~ rotated ~6 ~ run function api:mob/summon
+    execute positioned ~0.7 ~101.5 ~2 rotated ~6 ~ run function api:mob/summon
 
 # 双子とRootの紐づけを行う
     execute store result storage asset:temp 9E.Uid int 1 run scoreboard players get @s 9E.Uid

--- a/Asset/data/asset/functions/mob/0338.corundum_twins/tick/.mcfunction
+++ b/Asset/data/asset/functions/mob/0338.corundum_twins/tick/.mcfunction
@@ -14,6 +14,13 @@
 # タイマー増加
     execute unless entity @s[tag=9E.State.Phase.Sync] run scoreboard players add @s 9E.SyncTimer 1
 
+# 待機タイマー減少
+# 双子が同時に待機している場合のみ増加する
+    execute if score @s 9E.IdleTimer matches 1.. run scoreboard players remove @s 9E.IdleTimer 1
+    # 一定以上待機タイマーが溜まった場合、二人が何らかの原因で動けなくなっていると判断し、強制的にシンクロ攻撃を発動する
+        execute if score @s 9E.IdleTimer matches 60.. run function asset:mob/0338.corundum_twins/tick/app/ai/3.sync
+        execute if score @s 9E.IdleTimer matches 60.. run scoreboard players set @s 9E.IdleTimer 0
+
 # シンクロ攻撃発動
     execute if score @s 9E.SyncTimer matches 900.. run tag @s add 9E.State.Phase.Sync.Reserve
     execute if entity @s[tag=9E.State.Phase.Sync.Reserve] if entity @e[type=wither_skeleton,tag=9F.Root,tag=9F.Target,tag=9F.State.Await] if entity @e[type=wither_skeleton,tag=9G.Root,tag=9G.Target,tag=9G.State.Await] run function asset:mob/0338.corundum_twins/tick/app/ai/3.sync

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/_index.d.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/_index.d.mcfunction
@@ -51,6 +51,7 @@
             #declare tag 9E.Root 処理用中心点
             #declare tag 9E.Remove 死亡処理を行わずに消去する
             #declare tag 9E.Temp.Target.Aec.0 中心点が召喚する位置取得用AEC
+            #declare tag 9E.Marker.SpawnPoint 中心点
     #
     # 共通
         #declare tag 9F.Root 処理用wither_skeleton

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/app/call_from_root/1.interrupt.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/app/call_from_root/1.interrupt.mcfunction
@@ -11,8 +11,11 @@
 # 状態リセット
     function asset:mob/0339.twins_sapphiel/app/general/7.reset_state
 
+# 中心点からあまりにも離れている場合、中心に戻る
+    execute if entity @s[tag=!9F.Temp.Animated] unless entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..30] run function asset:mob/0339.twins_sapphiel/tick/app/skill/select/7.return
+
 # なにも武器を持っていない場合、装備する
-    execute if entity @s[tag=!9F.State.Weapon.Hg,tag=!9F.State.Weapon.Sg] run function asset:mob/0339.twins_sapphiel/tick/app/skill/select/3.equip
+    execute if entity @s[tag=!9F.Temp.Animated,tag=!9F.State.Weapon.Hg,tag=!9F.State.Weapon.Sg] run function asset:mob/0339.twins_sapphiel/tick/app/skill/select/3.equip
 
 # ガード回数リセット
     scoreboard players set @s 9F.GuardCount 0

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/02_hg_idle/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/02_hg_idle/1.main.mcfunction
@@ -15,5 +15,10 @@
     execute if score @s 9F.AnimationTimer matches 1 run tag @s add 9F.State.IsGuard
     execute if score @s 9F.AnimationTimer matches 61 run tag @s remove 9F.State.IsGuard
 
+# 待機カウント増加
+    scoreboard players operation $Uid Temporary = @s 9E.Uid
+    execute as @e[type=slime,tag=9E.Root] if score @s 9E.Uid = $Uid Temporary at @s run function asset:mob/0338.corundum_twins/app/call_from_twins/5.idle_timer
+    scoreboard players reset $Uid Temporary
+
 # 終了
     execute if score @s 9F.AnimationTimer matches 61.. run function asset:mob/0339.twins_sapphiel/tick/app/skill/event_handler/02_hg_idle/2.end

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/06_1_hg_lowkick/5.1.damage_down.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/06_1_hg_lowkick/5.1.damage_down.mcfunction
@@ -13,7 +13,10 @@
     function asset:mob/0339.twins_sapphiel/app/general/6.teleport_to_land
 
 # 移動速度低下
-    effect give @s slowness 3 10 true
+    data modify storage api: Argument set value {ID:67,Duration:60,Stack:20}
+    function api:entity/mob/effect/give
+    function api:entity/mob/effect/reset
+    # effect give @s slowness 3 10 true
 
 # 転倒演出
     data modify storage api: Argument.ID set value 2196

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/40_1_damage_start/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/40_1_damage_start/1.main.mcfunction
@@ -13,10 +13,10 @@
     execute if score @s 9F.AnimationTimer matches 1 run function asset:mob/0339.twins_sapphiel/tick/app/skill/event_handler/40_1_damage_start/4.notify
 
 # 移動
-    execute if score @s 9F.AnimationTimer matches 1..12 at @s positioned ^ ^ ^-0.5 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
-    execute if score @s 9F.AnimationTimer matches 13..18 at @s positioned ^ ^ ^-0.3 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
-    execute if score @s 9F.AnimationTimer matches 19..21 at @s positioned ^ ^ ^-0.1 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
-    execute if score @s 9F.AnimationTimer matches 1..21 at @s positioned ^ ^-0.1 ^ run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
+    execute if score @s 9F.AnimationTimer matches 1..12 at @s if entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..23.5] positioned ^ ^ ^-0.5 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
+    execute if score @s 9F.AnimationTimer matches 13..18 at @s if entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..23.5] positioned ^ ^ ^-0.3 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
+    execute if score @s 9F.AnimationTimer matches 19..21 at @s if entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..23.5] positioned ^ ^ ^-0.1 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
+    execute if score @s 9F.AnimationTimer matches 1..21 at @s if entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..23.5] positioned ^ ^-0.1 ^ run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
 
 # 状態更新
     execute if score @s 9F.AnimationTimer matches 1 run tag @s remove 9F.State.IsReload

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/40_2_damage_down/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/40_2_damage_down/1.main.mcfunction
@@ -9,7 +9,7 @@
     execute if score @s 9F.AnimationTimer matches 1 run function asset:mob/0339.twins_sapphiel/tick/app/skill/event_handler/40_2_damage_down/3.play_animation
 
 # 移動
-    execute if score @s 9F.AnimationTimer matches 1..31 at @s positioned ^ ^-0.1 ^ run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
+    # execute if score @s 9F.AnimationTimer matches 1..31 at @s positioned ^ ^-0.1 ^ run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
 
 # 終了
     execute if score @s 9F.AnimationTimer matches 31.. run function asset:mob/0339.twins_sapphiel/tick/app/skill/event_handler/40_2_damage_down/2.end

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/40_3_damage_end/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/40_3_damage_end/1.main.mcfunction
@@ -14,8 +14,9 @@
 # 移動
     execute if score @s 9F.AnimationTimer matches 17 run function asset:mob/0339.twins_sapphiel/app/general/6.teleport_to_land
     execute if score @s 9F.AnimationTimer matches 18 facing entity @p feet run tp @s ~ ~ ~ ~ 0
-    execute if score @s 9F.AnimationTimer matches 18 at @s run tp @s ^ ^0.5 ^-6
-    execute if score @s 9F.AnimationTimer matches 18 at @s positioned ^ ^ ^-6 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
+    # 中心点から遠い場合は、中心に向かって移動
+        execute if score @s 9G.AnimationTimer matches 18 if entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..17] at @s positioned ^ ^ ^-6 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
+        execute if score @s 9G.AnimationTimer matches 18 unless entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..17] at @s facing entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..17,limit=1] feet rotated ~ 0 positioned ^ ^ ^6 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
 # 移動演出
     execute if score @s 9F.AnimationTimer matches 18 run playsound item.trident.return hostile @a ~ ~ ~ 1 1.2
     execute if score @s 9F.AnimationTimer matches 18 run particle flash ~ ~1 ~ 0 0 0 0 1

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/40_3_damage_end/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/40_3_damage_end/1.main.mcfunction
@@ -15,8 +15,8 @@
     execute if score @s 9F.AnimationTimer matches 17 run function asset:mob/0339.twins_sapphiel/app/general/6.teleport_to_land
     execute if score @s 9F.AnimationTimer matches 18 facing entity @p feet run tp @s ~ ~ ~ ~ 0
     # 中心点から遠い場合は、中心に向かって移動
-        execute if score @s 9G.AnimationTimer matches 18 if entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..17] at @s positioned ^ ^ ^-6 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
-        execute if score @s 9G.AnimationTimer matches 18 unless entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..17] at @s facing entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..17,limit=1] feet rotated ~ 0 positioned ^ ^ ^6 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
+        execute if score @s 9G.AnimationTimer matches 18 if entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..15] at @s positioned ^ ^0.5 ^-10 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
+        execute if score @s 9G.AnimationTimer matches 18 unless entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..15] at @s facing entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..17,limit=1] feet rotated ~ 0 positioned ^ ^0.5 ^8 run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
 # 移動演出
     execute if score @s 9F.AnimationTimer matches 18 run playsound item.trident.return hostile @a ~ ~ ~ 1 1.2
     execute if score @s 9F.AnimationTimer matches 18 run particle flash ~ ~1 ~ 0 0 0 0 1

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/40_5_damage_stun/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/event_handler/40_5_damage_stun/1.main.mcfunction
@@ -9,7 +9,7 @@
     execute if score @s 9F.AnimationTimer matches 1 run function asset:mob/0339.twins_sapphiel/tick/app/skill/event_handler/40_5_damage_stun/3.play_animation
 
 # 移動
-    execute if score @s 9F.AnimationTimer matches 1..31 at @s positioned ^ ^-0.1 ^ run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
+    # execute if score @s 9F.AnimationTimer matches 1..31 at @s positioned ^ ^-0.1 ^ run function asset:mob/0339.twins_sapphiel/app/general/3.teleport
 
 # 演出
     execute if score @s 9F.AnimationTimer matches 5 run particle crit ^ ^1.6 ^-0.1 0.2 0 0.2 0.1 3

--- a/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/select/7.return.mcfunction
+++ b/Asset/data/asset/functions/mob/0339.twins_sapphiel/tick/app/skill/select/7.return.mcfunction
@@ -1,0 +1,15 @@
+#> asset:mob/0339.twins_sapphiel/tick/app/skill/select/7.return
+#
+# 中心に戻る
+#
+# @within
+#    function asset:mob/0339.twins_sapphiel/app/call_from_root/1.interrupt
+
+# 移動位置
+    execute at @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..50] run summon area_effect_cloud ^1.8 ^1 ^ {CustomNameVisible:0b,Particle:"block air",Duration:17,Tags:["Object","9F.Temp.Target.Aec.0"]}
+
+# 移動開始
+    tag @s add 9F.Skill.Sync.Goalong
+
+# 終了
+    tag @s add 9F.Temp.Animated

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/_index.d.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/_index.d.mcfunction
@@ -61,6 +61,7 @@
             #declare tag 9E.Root 処理用中心点
             #declare tag 9E.Remove 死亡処理を行わずに消去する
             #declare tag 9E.Temp.Target.Aec.0 中心点が召喚する位置取得用AEC
+            #declare tag 9E.Marker.SpawnPoint 中心点
     #
     # 共通
         #declare tag 9G.Root 処理用wither_skeleton

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/app/call_from_root/1.interrupt.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/app/call_from_root/1.interrupt.mcfunction
@@ -14,8 +14,12 @@
 # 状態リセット
     function asset:mob/0340.twins_rubiel/app/general/8.reset_state
 
+# 中心点からあまりにも離れている場合、中心に戻る
+    execute if entity @s[tag=!9G.Temp.Animated] unless entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..30] run function asset:mob/0340.twins_rubiel/tick/app/skill/select/7.return
+    # execute if entity @s[tag=!9G.Temp.Animated] run function asset:mob/0340.twins_rubiel/tick/app/skill/select/7.return
+
 # なにも武器を持っていない場合、装備する
-    execute if entity @s[tag=!9G.State.Weapon.Kt,tag=!9G.State.Weapon.Sc] run function asset:mob/0340.twins_rubiel/tick/app/skill/select/3.equip
+    execute if entity @s[tag=!9G.Temp.Animated,tag=!9G.State.Weapon.Kt,tag=!9G.State.Weapon.Sc] run function asset:mob/0340.twins_rubiel/tick/app/skill/select/3.equip
 
 # ガード回数リセット
     scoreboard players set @s 9G.GuardCount 0
@@ -25,7 +29,7 @@
     execute if entity @s[tag=9G.Skill.Kt.Draw.Jumonji] run tag @s remove 9G.Skill.Kt.Sheathe.Wait.Jumonji
 
 # ランダムで行動させる
-    execute unless entity @s[tag=9G.Skill.Kt.Draw.Jumonji] run function asset:mob/0340.twins_rubiel/tick/app/skill/select/5.1.interrupt_kt
+    execute if entity @s[tag=!9G.Temp.Animated,tag=!9G.Skill.Kt.Draw.Jumonji] run function asset:mob/0340.twins_rubiel/tick/app/skill/select/5.1.interrupt_kt
 
 # 終了
     tag @s remove 9G.Temp.Animated.Draw

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/02_kt_idle/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/02_kt_idle/1.main.mcfunction
@@ -17,10 +17,14 @@
     execute if score @s 9G.AnimationTimer matches 30 if score @s 9G.MoodPoint matches ..-50 run particle angry_villager ~ ~2.2 ~ 0.3 0.3 0.3 0 1
     execute if score @s 9G.AnimationTimer matches 45 if score @s 9G.MoodPoint matches ..-50 run particle angry_villager ~ ~2.2 ~ 0.3 0.3 0.3 0 1
 
-
 # ガード受け付け
     execute if score @s 9G.AnimationTimer matches 1 run tag @s add 9G.State.IsGuard
     execute if score @s 9G.AnimationTimer matches 61 run tag @s remove 9G.State.IsGuard
+
+# 待機カウント増加
+    scoreboard players operation $Uid Temporary = @s 9E.Uid
+    execute as @e[type=slime,tag=9E.Root] if score @s 9E.Uid = $Uid Temporary at @s run function asset:mob/0338.corundum_twins/app/call_from_twins/5.idle_timer
+    scoreboard players reset $Uid Temporary
 
 # 終了
     execute if score @s 9G.AnimationTimer matches 61.. run function asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/02_kt_idle/2.end

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/08_2_kt_throw/5.1.damage_catch.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/08_2_kt_throw/5.1.damage_catch.mcfunction
@@ -18,7 +18,10 @@
 
 # 演出
     execute if entity @a[tag=9G.Temp.Target.Attack] run playsound ogg:entity.player.attack.knockback4 hostile @a ~ ~ ~ 2 1.3
-    effect give @a[tag=9G.Temp.Target.Attack] slowness 2 20 true
+    data modify storage api: Argument set value {ID:67,Duration:40,Stack:20}
+    execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:entity/mob/effect/give
+    function api:entity/mob/effect/reset
+    # effect give @a[tag=9G.Temp.Target.Attack] slowness 2 20 true
     execute as @a[tag=9G.Temp.Target.Attack] at @s run tp @s @s
 
 # 気分を上昇

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/08_2_kt_throw/5.3.damage_down.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/08_2_kt_throw/5.3.damage_down.mcfunction
@@ -13,7 +13,10 @@
     function asset:mob/0340.twins_rubiel/app/general/6.teleport_to_land
 
 # 移動速度低下
-    effect give @s slowness 3 10 true
+    # effect give @s slowness 3 10 true
+    data modify storage api: Argument set value {ID:67,Duration:60,Stack:20}
+    function api:entity/mob/effect/give
+    function api:entity/mob/effect/reset
 
 # 演出
     execute at @s anchored eyes run particle explosion ~ ~0.5 ~ 0 0 0 0 1

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/31_2_sync_crossfire_upper/5.damage.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/31_2_sync_crossfire_upper/5.damage.mcfunction
@@ -25,7 +25,15 @@
     execute if entity @a[tag=9G.Temp.Target.Attack] run playsound ogg:entity.player.attack.knockback4 hostile @a ~ ~ ~ 2 1.3
 
 # かちあげ
-    execute at @a[tag=9G.Temp.Target.Attack] run summon area_effect_cloud ~ ~ ~ {Particle:"cloud",Radius:0.5f,Duration:6,Age:4,effects:[{id:"levitation",amplifier:30b,duration:5,show_particles:0b},{id:"minecraft:slow_falling",amplifier:0b,duration:60,show_particles:0b}]}
+    # 浮遊
+        data modify storage api: Argument set value {ID:125,Duration:5,Stack:30}
+        execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:entity/mob/effect/give
+        function api:entity/mob/effect/reset
+    # 低速落下
+        data modify storage api: Argument set value {ID:81,Duration:60,Stack:1}
+        execute as @a[tag=9G.Temp.Target.Attack] at @s run function api:entity/mob/effect/give
+        function api:entity/mob/effect/reset
+    # execute at @a[tag=9G.Temp.Target.Attack] run summon area_effect_cloud ~ ~ ~ {Particle:"cloud",Radius:0.5f,Duration:6,Age:4,effects:[{id:"levitation",amplifier:30b,duration:5,show_particles:0b},{id:"minecraft:slow_falling",amplifier:0b,duration:60,show_particles:0b}]}
 
 # Rootにヒット通知
     scoreboard players operation $Uid Temporary = @s 9E.Uid

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/40_1_damage_start/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/40_1_damage_start/1.main.mcfunction
@@ -13,10 +13,10 @@
     execute if score @s 9G.AnimationTimer matches 1 run function asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/40_1_damage_start/4.notify
 
 # 移動
-    execute if score @s 9G.AnimationTimer matches 1..12 at @s positioned ^ ^ ^-0.5 run function asset:mob/0340.twins_rubiel/app/general/3.teleport
-    execute if score @s 9G.AnimationTimer matches 13..18 at @s positioned ^ ^ ^-0.3 run function asset:mob/0340.twins_rubiel/app/general/3.teleport
-    execute if score @s 9G.AnimationTimer matches 19..21 at @s positioned ^ ^ ^-0.1 run function asset:mob/0340.twins_rubiel/app/general/3.teleport
-    execute if score @s 9G.AnimationTimer matches 1..21 at @s positioned ^ ^-0.1 ^ run function asset:mob/0340.twins_rubiel/app/general/3.teleport
+    execute if score @s 9G.AnimationTimer matches 1..12 at @s if entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..23.5] positioned ^ ^ ^-0.5 run function asset:mob/0340.twins_rubiel/app/general/3.teleport
+    execute if score @s 9G.AnimationTimer matches 13..18 at @s if entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..23.5] positioned ^ ^ ^-0.3 run function asset:mob/0340.twins_rubiel/app/general/3.teleport
+    execute if score @s 9G.AnimationTimer matches 19..21 at @s if entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..23.5] positioned ^ ^ ^-0.1 run function asset:mob/0340.twins_rubiel/app/general/3.teleport
+    execute if score @s 9G.AnimationTimer matches 1..21 at @s if entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..23.5] positioned ^ ^-0.1 ^ run function asset:mob/0340.twins_rubiel/app/general/3.teleport
 
 # 終了
     execute if score @s 9G.AnimationTimer matches 21.. run function asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/40_1_damage_start/2.end

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/40_2_damage_down/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/40_2_damage_down/1.main.mcfunction
@@ -9,7 +9,7 @@
     execute if score @s 9G.AnimationTimer matches 1 run function asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/40_2_damage_down/3.play_animation
 
 # 移動
-    execute if score @s 9G.AnimationTimer matches 1..31 at @s positioned ^ ^-0.1 ^ run function asset:mob/0340.twins_rubiel/app/general/3.teleport
+    # execute if score @s 9G.AnimationTimer matches 1..31 at @s positioned ^ ^-0.1 ^ run function asset:mob/0340.twins_rubiel/app/general/3.teleport
 
 # 終了
     execute if score @s 9G.AnimationTimer matches 31.. run function asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/40_2_damage_down/2.end

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/40_3_damage_end/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/40_3_damage_end/1.main.mcfunction
@@ -14,8 +14,9 @@
 # 移動
     execute if score @s 9G.AnimationTimer matches 17 run function asset:mob/0340.twins_rubiel/app/general/6.teleport_to_land
     execute if score @s 9G.AnimationTimer matches 18 facing entity @p feet run tp @s ~ ~ ~ ~ 0
-    execute if score @s 9G.AnimationTimer matches 18 at @s run tp @s ^ ^0.5 ^-6
-    execute if score @s 9G.AnimationTimer matches 18 at @s positioned ^ ^ ^-6 run function asset:mob/0340.twins_rubiel/app/general/3.teleport
+    # 中心点から遠い場合は、中心に向かって移動
+        execute if score @s 9G.AnimationTimer matches 18 if entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..17] at @s positioned ^ ^ ^-6 run function asset:mob/0340.twins_rubiel/app/general/3.teleport
+        execute if score @s 9G.AnimationTimer matches 18 unless entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..17] at @s facing entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..17,limit=1] feet rotated ~ 0 positioned ^ ^ ^6 run function asset:mob/0340.twins_rubiel/app/general/3.teleport
 # 移動演出
     execute if score @s 9G.AnimationTimer matches 18 run playsound item.trident.return hostile @a ~ ~ ~ 1 1.2
     execute if score @s 9G.AnimationTimer matches 18 run particle flash ~ ~1 ~ 0 0 0 0 1

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/40_3_damage_end/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/40_3_damage_end/1.main.mcfunction
@@ -15,8 +15,8 @@
     execute if score @s 9G.AnimationTimer matches 17 run function asset:mob/0340.twins_rubiel/app/general/6.teleport_to_land
     execute if score @s 9G.AnimationTimer matches 18 facing entity @p feet run tp @s ~ ~ ~ ~ 0
     # 中心点から遠い場合は、中心に向かって移動
-        execute if score @s 9G.AnimationTimer matches 18 if entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..17] at @s positioned ^ ^ ^-6 run function asset:mob/0340.twins_rubiel/app/general/3.teleport
-        execute if score @s 9G.AnimationTimer matches 18 unless entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..17] at @s facing entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..17,limit=1] feet rotated ~ 0 positioned ^ ^ ^6 run function asset:mob/0340.twins_rubiel/app/general/3.teleport
+        execute if score @s 9G.AnimationTimer matches 18 if entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..15] at @s positioned ^ ^0.5 ^-10 run function asset:mob/0340.twins_rubiel/app/general/3.teleport
+        execute if score @s 9G.AnimationTimer matches 18 unless entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..15] at @s facing entity @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..17,limit=1] feet rotated ~ 0 positioned ^ ^0.5 ^8 run function asset:mob/0340.twins_rubiel/app/general/3.teleport
 # 移動演出
     execute if score @s 9G.AnimationTimer matches 18 run playsound item.trident.return hostile @a ~ ~ ~ 1 1.2
     execute if score @s 9G.AnimationTimer matches 18 run particle flash ~ ~1 ~ 0 0 0 0 1

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/40_5_damage_stun/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/event_handler/40_5_damage_stun/1.main.mcfunction
@@ -9,7 +9,7 @@
     execute if score @s 9G.AnimationTimer matches 1 run function asset:mob/0340.twins_rubiel/tick/app/skill/event_handler/40_5_damage_stun/3.play_animation
 
 # 移動
-    execute if score @s 9G.AnimationTimer matches 1..31 at @s positioned ^ ^-0.1 ^ run function asset:mob/0340.twins_rubiel/app/general/3.teleport
+    # execute if score @s 9G.AnimationTimer matches 1..31 at @s positioned ^ ^-0.1 ^ run function asset:mob/0340.twins_rubiel/app/general/3.teleport
 
 # 演出
     execute if score @s 9G.AnimationTimer matches 5 run particle crit ^ ^1.6 ^-0.1 0.2 0 0.2 0.1 3

--- a/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/select/7.return.mcfunction
+++ b/Asset/data/asset/functions/mob/0340.twins_rubiel/tick/app/skill/select/7.return.mcfunction
@@ -1,0 +1,15 @@
+#> asset:mob/0340.twins_rubiel/tick/app/skill/select/7.return
+#
+# 中心に戻る
+#
+# @within function asset:mob/0340.twins_rubiel/app/call_from_root/1.interrupt
+
+# ランダム
+# 移動位置
+    execute at @e[type=marker,tag=9E.Marker.SpawnPoint,distance=..50] run summon area_effect_cloud ^-1.8 ^1 ^ {CustomNameVisible:0b,Particle:"block air",Duration:17,Tags:["Object","9G.Temp.Target.Aec.0"]}
+
+# 移動開始
+    tag @s add 9G.Skill.Sync.Goalong
+
+# 終了
+    tag @s add 9G.Temp.Animated


### PR DESCRIPTION
### 修正内容
- サフィが消える問題
    - ダウン中の移動、ダウン後の復帰などに中心点との距離に応じた分岐を追加
    - 中心点から離れすぎている場合は中心に帰るよう修正
- 上記変更により、役割を放棄してどこかに遊びに行くことは少なくなったと思う。ただし、双子の気分次第なので完全に治せているかはわからない
    - #1425
    - #1536
- 双子が使用するEffectをEffectAssetに変更
    - #1520
- 場当たり的対策ではあるものの、双子が同時に待機（動かなくなった）場合のみ増加するスコアを追加。それが一定以上になった場合、強制的にシンクロ攻撃を発動して状況を改善する
    - #719
