### PR TITLE
[Mob 327] エクレール Issue対応

### DIFF
--- a/Asset/data/asset/functions/mob/0327.eclael/_index.d.mcfunction
+++ b/Asset/data/asset/functions/mob/0327.eclael/_index.d.mcfunction
@@ -143,6 +143,7 @@
     #declare tag 93.Temp.PrepareGuard ガード可能状態，この間に攻撃されるとガードに移行する
     #declare tag 93.Temp.Guard ガード中判別用
     #declare tag 93.Temp.IsThunder 天候が雷雨である
+    #declare tag 93.Temp.Target 一部攻撃に使用、避けやすいよう特定のプレイヤーのみを狙う
     #
     ## スキル：前半
     #declare tag 93.Skill.Former.Start 登場演出

--- a/Asset/data/asset/functions/mob/0327.eclael/init/.mcfunction
+++ b/Asset/data/asset/functions/mob/0327.eclael/init/.mcfunction
@@ -20,8 +20,11 @@
 # 中心点召喚
     summon marker ~ ~2.5 ~ {Tags:["93.Marker.SpawnPoint"]}
 
+# モデルが見えやすいように前に移動
+    tp @s ^ ^ ^2
+
 # animated javaモデル召喚
-    execute positioned ~ ~-20 ~ rotated ~ 0 run function animated_java:eclael/summon {args:{animation: '29_0_phase_start', start_animation: true}}
+    execute at @s positioned ~ ~-20 ~ rotated ~ 0 run function animated_java:eclael/summon {args:{animation: '29_0_phase_start', start_animation: true}}
 
 # 登場演出再生
     tag @s add 93.Skill.Former.Start

--- a/Asset/data/asset/functions/mob/0327.eclael/load.mcfunction
+++ b/Asset/data/asset/functions/mob/0327.eclael/load.mcfunction
@@ -16,3 +16,5 @@
     scoreboard objectives add 93.DamageTimer dummy
     # 処理用カウンター
     scoreboard objectives add 93.TempCount dummy
+    # ターゲット
+    scoreboard objectives add 93.TargetUserId dummy

--- a/Asset/data/asset/functions/mob/0327.eclael/tick/app.general/check_target.m.mcfunction
+++ b/Asset/data/asset/functions/mob/0327.eclael/tick/app.general/check_target.m.mcfunction
@@ -1,0 +1,8 @@
+#> asset:mob/0327.eclael/tick/app.general/check_target
+#
+# 汎用処理 ターゲット取得
+#
+# @within asset:mob/0327.eclael/tick/**
+
+# 対象にタグを付与
+    $tag @a[scores={UserID=$(TargetUserId)}] add 93.Temp.Target

--- a/Asset/data/asset/functions/mob/0327.eclael/tick/app.general/check_target.mcfunction
+++ b/Asset/data/asset/functions/mob/0327.eclael/tick/app.general/check_target.mcfunction
@@ -1,0 +1,12 @@
+#> asset:mob/0327.eclael/tick/app.general/check_target
+#
+# 汎用処理 ターゲット取得
+#
+# @within asset:mob/0327.eclael/tick/**
+
+# 対象にタグを付与
+    execute store result storage asset:temp 93.TargetUserId int 1 run scoreboard players get @s 93.TargetUserId
+    function asset:mob/0327.eclael/tick/app.general/check_target.m with storage asset:temp 93
+
+# 終了
+    data remove storage asset:temp 93

--- a/Asset/data/asset/functions/mob/0327.eclael/tick/app.general/update_target.mcfunction
+++ b/Asset/data/asset/functions/mob/0327.eclael/tick/app.general/update_target.mcfunction
@@ -1,0 +1,21 @@
+#> asset:mob/0327.eclael/tick/app.general/update_target
+#
+# 汎用処理 ターゲット更新
+#
+# @within asset:mob/0327.eclael/tick/**
+
+#> Private
+# @private
+    #declare objective UserId
+
+# ターゲットが近くにいるならスキップ
+    execute if entity @p[tag=93.Temp.Target,distance=..80] run return 0
+
+# ターゲット解放
+    tag @a remove 93.Temp.Target
+
+# 最も近くにいるプレイヤーをターゲットにする
+# サバイバルの対象が居ない場合、しょうがないのでそれ以外を狙う
+    tag @p[tag=!PlayerShouldInvulnerable,distance=..80] add 93.Temp.Target
+    execute unless entity @p[tag=93.Temp.Target,distance=..80] run tag @p add 93.Temp.Target
+    scoreboard players operation @s 93.TargetUserId = @p[tag=93.Temp.Target,distance=..80] UserId

--- a/Asset/data/asset/functions/mob/0327.eclael/tick/app.skill_events/00_1_former_idle_sleep/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0327.eclael/tick/app.skill_events/00_1_former_idle_sleep/1.main.mcfunction
@@ -5,6 +5,9 @@
 #
 # @within function asset:mob/0327.eclael/tick/app.2.skill_event
 
+# 中心点から離れすぎている場合、中心に戻る
+    execute if score @s 93.AnimationTimer matches 1 unless entity @e[type=marker,tag=93.Marker.SpawnPoint,distance=..23] positioned as @e[type=marker,tag=93.Marker.SpawnPoint,distance=..30,sort=nearest,limit=1] run tp @s ~ ~-2 ~ ~ 0
+
 ## あくび
 # animated javaアニメーション再生 (長さ：94tick)
     execute if score @s 93.AnimationTimer matches 1 run function asset:mob/0327.eclael/tick/app.skill_events/00_1_former_idle_sleep/3.1.play_start_animation

--- a/Asset/data/asset/functions/mob/0327.eclael/tick/app.skill_events/10_latter_idle/1.main.mcfunction
+++ b/Asset/data/asset/functions/mob/0327.eclael/tick/app.skill_events/10_latter_idle/1.main.mcfunction
@@ -9,7 +9,7 @@
     execute if score @s 93.AnimationTimer matches 1 run function asset:mob/0327.eclael/tick/app.skill_events/10_latter_idle/3.play_animation
 
 # ガード受け付け
-    execute if score @s 93.AnimationTimer matches 1 if predicate api:global_vars/difficulty/min/3_blessless run function asset:mob/0327.eclael/tick/app.general/11.start_guard_prepare
+    # execute if score @s 93.AnimationTimer matches 1 if predicate api:global_vars/difficulty/min/3_blessless run function asset:mob/0327.eclael/tick/app.general/11.start_guard_prepare
 
 # 表情
     execute if score @s 93.AnimationTimer matches 1 as @e[type=item_display,tag=93.ModelRoot.Target,distance=..80,sort=nearest,limit=1] run function animated_java:eclael/variants/default/apply

--- a/Asset/data/asset/functions/mob/0327.eclael/tick/app.skill_events/35_latter_beam/end.mcfunction
+++ b/Asset/data/asset/functions/mob/0327.eclael/tick/app.skill_events/35_latter_beam/end.mcfunction
@@ -10,5 +10,9 @@
 # タイマーリセット
     scoreboard players set @s 93.AnimationTimer 0
 
+# ターゲット解放
+    scoreboard players reset @s 93.TargetUserId
+    tag @a remove 93.Temp.Target
+
 # 居合に移行
     tag @s add 93.Skill.IaiMove

--- a/Asset/data/asset/functions/mob/0327.eclael/tick/app.skill_events/35_latter_beam/main.mcfunction
+++ b/Asset/data/asset/functions/mob/0327.eclael/tick/app.skill_events/35_latter_beam/main.mcfunction
@@ -4,15 +4,21 @@
 #
 # @within function asset:mob/0327.eclael/tick/app.2.skill_event
 
+# ターゲット保持
+    function asset:mob/0327.eclael/tick/app.general/check_target
+    function asset:mob/0327.eclael/tick/app.general/update_target
+
 # 開始
     execute if score @s 93.AnimationTimer matches 1 run function asset:mob/0327.eclael/tick/app.skill_events/35_latter_beam/animation_0
     # 中心点を挟んで反対側に移動
-        execute if score @s 93.AnimationTimer matches 1 positioned as @e[type=marker,tag=93.Marker.SpawnPoint,distance=..80,sort=nearest,limit=1] facing entity @p[tag=!PlayerShouldInvulnerable] feet positioned as @s run tp @s ~ ~ ~ ~ 0
+        # execute if score @s 93.AnimationTimer matches 1 positioned as @e[type=marker,tag=93.Marker.SpawnPoint,distance=..80,sort=nearest,limit=1] facing entity @p[tag=!PlayerShouldInvulnerable] feet positioned as @s run tp @s ~ ~ ~ ~ 0
+        execute if score @s 93.AnimationTimer matches 1 positioned as @e[type=marker,tag=93.Marker.SpawnPoint,distance=..80,sort=nearest,limit=1] facing entity @p[tag=93.Temp.Target] feet positioned as @s run tp @s ~ ~ ~ ~ 0
         execute if score @s 93.AnimationTimer matches 1 at @s as @e[type=marker,tag=93.Marker.SpawnPoint,distance=..80,sort=nearest,limit=1] positioned as @s run tp @s ~ ~ ~ ~0 0
         execute if score @s 93.AnimationTimer matches 5 at @e[type=marker,tag=93.Marker.SpawnPoint,distance=..80,sort=nearest,limit=1] run tp @s ^ ^-2.3 ^-10 ~ 0
     # プレイヤーの方を向く
         execute if score @s 93.AnimationTimer matches 6..101 run tag @s add 93.Temp.Me
-        execute if score @s 93.AnimationTimer matches 6..101 as @a[tag=!PlayerShouldInvulnerable,distance=..80,sort=nearest,limit=1] run function asset:mob/0327.eclael/tick/app.general/1.rotate
+        # execute if score @s 93.AnimationTimer matches 6..101 as @a[tag=!PlayerShouldInvulnerable,distance=..80,sort=nearest,limit=1] run function asset:mob/0327.eclael/tick/app.general/1.rotate
+        execute if score @s 93.AnimationTimer matches 6..101 as @a[tag=93.Temp.Target,distance=..80,sort=nearest,limit=1] run function asset:mob/0327.eclael/tick/app.general/1.rotate
     # 演出
         execute if score @s 93.AnimationTimer matches 1 run playsound entity.wither.shoot hostile @a[distance=..30] ~ ~ ~ 0.5 1.8 0.5
         execute if score @s 93.AnimationTimer matches 1 run playsound entity.guardian.attack hostile @a ~ ~ ~ 2 1.8
@@ -36,6 +42,9 @@
         execute if score @s 93.AnimationTimer matches 147 run playsound item.armor.equip_leather hostile @a ~ ~ ~ 2 1
     # 移動
         execute if score @s 93.AnimationTimer matches 147..156 at @s run tp @s ^ ^0.03 ^ ~ 0
+
+# ターゲット解放
+    tag @a remove 93.Temp.Target
 
 # 終了
     execute if score @s 93.AnimationTimer matches 170.. run function asset:mob/0327.eclael/tick/app.skill_events/35_latter_beam/end


### PR DESCRIPTION
### Issue対応
- 念のため、壁の外に出ていそうな場合は中心に戻ってから寝るようにした。前半戦で壁抜けするのは通常あり得ないので、特に演出もなく中心にワープする。もし頻発するなら何かしら演出を付ける
    - #1447
- 以下はすでに対応済み
    - #1463

### その他の変更
- 召喚位置をややずらしたので、かわいい伸びが存分に堪能できる
- マルチプレイで残心（剣伸ばすやつ）の対象がコロコロ変わると避けにくそうなので、対象を固定するようにした
- ガード受け付け処理が削除されず残っており、待機中常に耐性がかかっていた可能性がある。削除したので、おそらく耐性が掛かっていない前提で再度HPについて調整する必要があるかもしれない