### PR TITLE
[Mob 380] ハルクレアのバグ修正およびUX向上

### DIFF
--- a/Asset/data/asset/functions/mob/0380.haruclaire_v3/_index.d.mcfunction
+++ b/Asset/data/asset/functions/mob/0380.haruclaire_v3/_index.d.mcfunction
@@ -123,6 +123,7 @@
     #declare tag AK.Temp.AttackPosition.Hard 攻撃位置保持用
     #declare tag AK.Temp.AttackRotation 攻撃角度保持用
     #declare tag AK.Temp.Start 初期化処理の重複防止
+    #declare tag AK.Temp.IsRight アイスピラー回転方向
     #
     # - 他オブジェクト
     #declare tag AK.Object ハルクレアオブジェクト共通タグ

--- a/Asset/data/asset/functions/mob/0380.haruclaire_v3/death/.mcfunction
+++ b/Asset/data/asset/functions/mob/0380.haruclaire_v3/death/.mcfunction
@@ -22,11 +22,11 @@
     data modify storage api: Argument.ID set value 2158
     function api:object/summon
 
-# オブジェクト消去
-    execute as @e[tag=AK.Object] on passengers run kill @s
-    kill @e[tag=AK.Object]
-
 # オブジェクト用AJモデル消去
     function animated_java:ic_capri_aj/remove/all
     function animated_java:ic_tau_aj/remove/all
     function animated_java:ic_pisce_aj/remove/all
+
+# オブジェクト消去
+    execute as @e[tag=AK.Object] on passengers run kill @s
+    kill @e[tag=AK.Object]

--- a/Asset/data/asset/functions/mob/0380.haruclaire_v3/death/.mcfunction
+++ b/Asset/data/asset/functions/mob/0380.haruclaire_v3/death/.mcfunction
@@ -28,5 +28,5 @@
     function animated_java:ic_pisce_aj/remove/all
 
 # オブジェクト消去
-    execute as @e[tag=AK.Object] on passengers run kill @s
-    kill @e[tag=AK.Object]
+    execute as @e[tag=AK.Object,distance=..120] on passengers run kill @s
+    kill @e[tag=AK.Object,distance=..120]

--- a/Asset/data/asset/functions/mob/0380.haruclaire_v3/init/.mcfunction
+++ b/Asset/data/asset/functions/mob/0380.haruclaire_v3/init/.mcfunction
@@ -19,7 +19,7 @@
         function asset:mob/0380.haruclaire_v3/init/animated_java
 
 # 移動
-    tp @s ^ ^1 ^2
+    execute rotated ~ 0 run tp @s ^ ^1 ^2
 
 # スコア初期化
     scoreboard players set @s AK.ActionCount 0

--- a/Asset/data/asset/functions/mob/0380.haruclaire_v3/init/.mcfunction
+++ b/Asset/data/asset/functions/mob/0380.haruclaire_v3/init/.mcfunction
@@ -19,7 +19,7 @@
         function asset:mob/0380.haruclaire_v3/init/animated_java
 
 # 移動
-    tp @s ~ ~0.5 ~
+    tp @s ^ ^1 ^2
 
 # スコア初期化
     scoreboard players set @s AK.ActionCount 0

--- a/Asset/data/asset/functions/mob/0380.haruclaire_v3/remove/.mcfunction
+++ b/Asset/data/asset/functions/mob/0380.haruclaire_v3/remove/.mcfunction
@@ -18,14 +18,14 @@
         # execute as @e[type=item_display,tag=AK.ModelRoot] run function animated_java:haruclaire_aj/as_own_locator_entities {command:'function asset:mob/0410.heiloang/death/kill_hitbox'}
     function animated_java:haruclaire_aj/remove/all
 
-# オブジェクト消去
-    execute as @e[tag=AK.Object] on passengers run kill @s
-    kill @e[tag=AK.Object]
-
 # オブジェクト用AJモデル消去
     function animated_java:ic_capri_aj/remove/all
     function animated_java:ic_tau_aj/remove/all
     function animated_java:ic_pisce_aj/remove/all
+
+# オブジェクト消去
+    execute as @e[tag=AK.Object] on passengers run kill @s
+    kill @e[tag=AK.Object]
 
 # AJアンロード
     data modify storage asset:datapack ActivationState set value [{Datapack:"AJ_haruclaire_v3",Active:false}]

--- a/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/debug/interrupt.mcfunction
+++ b/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/debug/interrupt.mcfunction
@@ -18,4 +18,4 @@
 
 # イベント実行
     scoreboard players set @s AK.EventTimer 0
-    tag @s add AK.Skill.IceSpear
+    tag @s add AK.Skill.IcePillar

--- a/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/debug/interrupt.mcfunction
+++ b/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/debug/interrupt.mcfunction
@@ -18,4 +18,4 @@
 
 # イベント実行
     scoreboard players set @s AK.EventTimer 0
-    tag @s add AK.Skill.SuperIceBullet
+    tag @s add AK.Skill.IceSpear

--- a/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/debug/interrupt.mcfunction
+++ b/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/debug/interrupt.mcfunction
@@ -18,4 +18,4 @@
 
 # イベント実行
     scoreboard players set @s AK.EventTimer 0
-    tag @s add AK.Skill.IcePillar
+    tag @s add AK.Skill.IceCremation.FourCircle

--- a/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/event/ice_pillar/.mcfunction
+++ b/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/event/ice_pillar/.mcfunction
@@ -15,6 +15,7 @@
         execute if score @s AK.EventTimer matches 54 at @s run playsound entity.ender_dragon.flap hostile @a ~ ~ ~ 1 1.3
     # 攻撃
         execute if score @s AK.EventTimer matches 5 positioned ~ ~4 ~ run function asset:mob/0380.haruclaire_v3/tick/event/ice_pillar/summon_attack_position
+        execute if score @s AK.EventTimer matches 5 if predicate lib:random_pass_per/50 run tag @s add AK.Temp.IsRight
         execute if score @s AK.EventTimer matches 15 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=random,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_pillar/attack
         execute if score @s AK.EventTimer matches 20 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=random,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_pillar/attack
         execute if score @s AK.EventTimer matches 25 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=random,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_pillar/attack
@@ -22,6 +23,7 @@
         execute if score @s AK.EventTimer matches 35 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=random,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_pillar/attack
         execute if score @s AK.EventTimer matches 40 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=random,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_pillar/attack
         execute if score @s AK.EventTimer matches 45 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=random,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_pillar/attack
+        execute if score @s AK.EventTimer matches 46 run tag @s remove AK.Temp.IsRight
 
 # 終了
     execute if score @s AK.EventTimer matches 71.. run function asset:mob/0380.haruclaire_v3/tick/event/ice_pillar/end

--- a/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/event/ice_pillar/attack.mcfunction
+++ b/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/event/ice_pillar/attack.mcfunction
@@ -8,6 +8,7 @@
     data modify storage api: Argument.ID set value 2156
     data modify storage api: Argument.FieldOverride.Damage set from storage asset:context this.Damage.Pillar
     execute store result storage api: Argument.FieldOverride.MobUUID int 1 run scoreboard players get @s MobUUID
+    execute if entity @s[tag=AK.Temp.IsRight] run data modify storage api: Argument.FieldOverride.IsRight set value true
     function api:object/summon
 
 # 終了

--- a/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/event/ice_pillar_duo/.mcfunction
+++ b/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/event/ice_pillar_duo/.mcfunction
@@ -15,6 +15,7 @@
         execute if score @s AK.EventTimer matches 54 at @s run playsound entity.ender_dragon.flap hostile @a ~ ~ ~ 1 1.3
     # 攻撃
         execute if score @s AK.EventTimer matches 5 positioned ~ ~4 ~ run function asset:mob/0380.haruclaire_v3/tick/event/ice_pillar_duo/summon_attack_position
+        execute if score @s AK.EventTimer matches 5 if predicate lib:random_pass_per/50 run tag @s add AK.Temp.IsRight
         execute if score @s AK.EventTimer matches 15 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=random,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_pillar_duo/attack
         execute if score @s AK.EventTimer matches 20 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=random,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_pillar_duo/attack
         execute if score @s AK.EventTimer matches 25 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=random,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_pillar_duo/attack
@@ -22,6 +23,7 @@
         execute if score @s AK.EventTimer matches 35 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=random,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_pillar_duo/attack
         execute if score @s AK.EventTimer matches 40 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=random,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_pillar_duo/attack
         execute if score @s AK.EventTimer matches 45 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=random,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_pillar_duo/attack
+        execute if score @s AK.EventTimer matches 46 run tag @s remove AK.Temp.IsRight
 
 # 終了
     execute if score @s AK.EventTimer matches 71.. run function asset:mob/0380.haruclaire_v3/tick/event/ice_pillar_duo/end

--- a/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/event/ice_pillar_duo/attack.mcfunction
+++ b/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/event/ice_pillar_duo/attack.mcfunction
@@ -8,6 +8,7 @@
     data modify storage api: Argument.ID set value 2156
     data modify storage api: Argument.FieldOverride.Damage set from storage asset:context this.Damage.Pillar
     execute store result storage api: Argument.FieldOverride.MobUUID int 1 run scoreboard players get @s MobUUID
+    execute if entity @s[tag=AK.Temp.IsRight] run data modify storage api: Argument.FieldOverride.IsRight set value true
     function api:object/summon
 
 # 終了

--- a/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/event/ice_spear/.mcfunction
+++ b/Asset/data/asset/functions/mob/0380.haruclaire_v3/tick/event/ice_spear/.mcfunction
@@ -38,13 +38,13 @@
         execute if score @s AK.EventTimer matches 105 if predicate api:global_vars/difficulty/min/3_blessless as @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=random,limit=2] run tag @s add AK.IceSpear.Spread
 
     # 攻撃
-        execute if score @s AK.EventTimer matches 35..38 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=arbitrary,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_spear/attack
-        execute if score @s AK.EventTimer matches 54..57 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=arbitrary,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_spear/attack
-        execute if score @s AK.EventTimer matches 73..76 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=arbitrary,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_spear/attack
-        execute if score @s AK.EventTimer matches 87..90 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=arbitrary,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_spear/attack
-        execute if score @s AK.EventTimer matches 96..99 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=arbitrary,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_spear/attack
-        execute if score @s AK.EventTimer matches 115..150 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,tag=!AK.IceSpear.Spread,distance=..80,sort=arbitrary,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_spear/attack
-        execute if score @s AK.EventTimer matches 120 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,tag=AK.IceSpear.Spread,distance=..80] run function asset:mob/0380.haruclaire_v3/tick/event/ice_spear/attack_spread
+        execute if score @s AK.EventTimer matches 40..43 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=arbitrary,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_spear/attack
+        execute if score @s AK.EventTimer matches 59..62 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=arbitrary,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_spear/attack
+        execute if score @s AK.EventTimer matches 78..81 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=arbitrary,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_spear/attack
+        execute if score @s AK.EventTimer matches 92..95 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=arbitrary,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_spear/attack
+        execute if score @s AK.EventTimer matches 101..104 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,distance=..80,sort=arbitrary,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_spear/attack
+        execute if score @s AK.EventTimer matches 120..155 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,tag=!AK.IceSpear.Spread,distance=..80,sort=arbitrary,limit=1] run function asset:mob/0380.haruclaire_v3/tick/event/ice_spear/attack
+        execute if score @s AK.EventTimer matches 125 at @e[type=area_effect_cloud,tag=AK.Temp.AttackPosition,tag=AK.IceSpear.Spread,distance=..80] run function asset:mob/0380.haruclaire_v3/tick/event/ice_spear/attack_spread
 
     # 地面に戻る
         execute if score @s AK.EventTimer matches 136.. if block ~ ~-0.7 ~ #lib:no_collision positioned ^ ^-0.08 ^ run function asset:mob/0380.haruclaire_v3/tick/util/tp

--- a/Asset/data/asset/functions/object/2156.haruclaire_icepillar/init/.mcfunction
+++ b/Asset/data/asset/functions/object/2156.haruclaire_icepillar/init/.mcfunction
@@ -14,4 +14,5 @@
     execute on passengers run tp @s ~ ~ ~ ~ 0
 
 # 回転方向決定
-    execute if predicate lib:random_pass_per/50 run tag @s add 2156.Right
+    execute if data storage asset:context this.IsRight run tag @s add 2156.Right
+    # execute if predicate lib:random_pass_per/50 run tag @s add 2156.Right


### PR DESCRIPTION
### 修正内容
- アイススピアが想定より早く発生して回避不能になっていたっぽいので、発生を遅くした。たぶんダメージを下げる必要はない
    - Fix #1545
- ハルクレアのkillまたはremobe時に、消えない氷像を飾っていく問題を修正。実行順が駄目だったようだ
    - Fix #1431
- マルチにおいて、アイスピラーを複数同時設置する場合においても、全て回転方向を揃えて出すよう修正。プレイヤー全員で時計/半時計に回れば回避不能パターンは生まれないはず
- 召喚位置を少しずらして、お辞儀を見えやすくした