### PR TITLE
🐛 [Artifact 724-727] 忘却の白雪装備のダメージ表記ミスを修正

### DIFF
--- a/Asset/data/asset/functions/artifact/0724.oblivious_snow/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0724.oblivious_snow/give/2.give.mcfunction
@@ -29,7 +29,7 @@
 # 神器の発動条件 (TextComponentString) (オプション)
     # data modify storage asset:artifact Condition set value
 # 攻撃に関する情報 -Damage量 (literal[]/literal) Wikiを参照 (オプション)
-    data modify storage asset:artifact AttackInfo.Damage set value 200
+    data modify storage asset:artifact AttackInfo.Damage set value [100]
 # 攻撃に関する情報 -攻撃タイプ (string[]) Wikiを参照 (オプション)
     data modify storage asset:artifact AttackInfo.AttackType set value [Physical]
 # 攻撃に関する情報 -攻撃属性 (string[]) Wikiを参照 (オプション)

--- a/Asset/data/asset/functions/artifact/0725.oblivious_snow/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0725.oblivious_snow/give/2.give.mcfunction
@@ -29,7 +29,7 @@
 # 神器の発動条件 (TextComponentString) (オプション)
     # data modify storage asset:artifact Condition set value
 # 攻撃に関する情報 -Damage量 (literal[]/literal) Wikiを参照 (オプション)
-    data modify storage asset:artifact AttackInfo.Damage set value 200
+    data modify storage asset:artifact AttackInfo.Damage set value [100]
 # 攻撃に関する情報 -攻撃タイプ (string[]) Wikiを参照 (オプション)
     data modify storage asset:artifact AttackInfo.AttackType set value [Physical]
 # 攻撃に関する情報 -攻撃属性 (string[]) Wikiを参照 (オプション)

--- a/Asset/data/asset/functions/artifact/0726.oblivious_snow/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0726.oblivious_snow/give/2.give.mcfunction
@@ -29,7 +29,7 @@
 # 神器の発動条件 (TextComponentString) (オプション)
     # data modify storage asset:artifact Condition set value
 # 攻撃に関する情報 -Damage量 (literal[]/literal) Wikiを参照 (オプション)
-    data modify storage asset:artifact AttackInfo.Damage set value 200
+    data modify storage asset:artifact AttackInfo.Damage set value [100]
 # 攻撃に関する情報 -攻撃タイプ (string[]) Wikiを参照 (オプション)
     data modify storage asset:artifact AttackInfo.AttackType set value [Physical]
 # 攻撃に関する情報 -攻撃属性 (string[]) Wikiを参照 (オプション)

--- a/Asset/data/asset/functions/artifact/0727.oblivious_snow/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0727.oblivious_snow/give/2.give.mcfunction
@@ -29,7 +29,7 @@
 # 神器の発動条件 (TextComponentString) (オプション)
     # data modify storage asset:artifact Condition set value
 # 攻撃に関する情報 -Damage量 (literal[]/literal) Wikiを参照 (オプション)
-    data modify storage asset:artifact AttackInfo.Damage set value 200
+    data modify storage asset:artifact AttackInfo.Damage set value [100]
 # 攻撃に関する情報 -攻撃タイプ (string[]) Wikiを参照 (オプション)
     data modify storage asset:artifact AttackInfo.AttackType set value [Physical]
 # 攻撃に関する情報 -攻撃属性 (string[]) Wikiを参照 (オプション)


### PR DESCRIPTION
Fix #1614