### PR TITLE
🐛 [Mob390-393] ウサギたちの初期地点マーカーが増殖するバグを修正

### DIFF
--- a/Asset/data/asset/functions/mob/0390.triple_rabbits/remove/.mcfunction
+++ b/Asset/data/asset/functions/mob/0390.triple_rabbits/remove/.mcfunction
@@ -4,18 +4,7 @@
 #
 # @within asset:mob/alias/390/remove
 
-#> function
-# @private
-    #declare function animated_java:axia/remove/all
-    #declare function animated_java:ecual/remove/all
-    #declare function animated_java:labyria/remove/all
-
-# モデル削除（削除されていないときのために）
-    function animated_java:axia/remove/all
-    function animated_java:ecual/remove/all
-    function animated_java:labyria/remove/all
-
-# キルする
+# Removeする
     scoreboard players operation $AU.Temp AU.Dummy.UUID = @s AU.Dummy.UUID
     execute as @e[type=wither_skeleton,tag=AU.Target,distance=..100] if score @s AU.Dummy.UUID = $AU.Temp AU.Dummy.UUID run data modify entity @s DeathLootTable set value "empty"
     execute as @e[type=wither_skeleton,tag=AU.Target,distance=..100] if score @s AU.Dummy.UUID = $AU.Temp AU.Dummy.UUID run function api:mob/remove

--- a/Asset/data/asset/functions/mob/0391.axia_first/remove/.mcfunction
+++ b/Asset/data/asset/functions/mob/0391.axia_first/remove/.mcfunction
@@ -1,0 +1,15 @@
+#> asset:mob/0391.axia_first/remove/
+#
+# 天使が居なくなる際に実行される処理
+#
+# @within asset:mob/alias/391/remove
+
+# モデル削除
+    function animated_java:axia/remove/all
+
+# ディスプレイ削除
+    kill @e[type=item_display,tag=AV.AnnounceLine,distance=..200]
+    kill @e[type=marker,tag=AV.Marker.SummonPoint,distance=..200]
+
+# 継承元の処理
+    function asset:mob/super.remove

--- a/Asset/data/asset/functions/mob/0392.ecual_first/remove/.mcfunction
+++ b/Asset/data/asset/functions/mob/0392.ecual_first/remove/.mcfunction
@@ -1,0 +1,16 @@
+#> asset:mob/0392.ecual_first/remove/
+#
+# 天使が居なくなる際に実行される処理
+#
+# @within asset:mob/alias/392/remove
+
+# モデル削除
+    function animated_java:ecual/remove/all
+
+# ディスプレイ削除
+    kill @e[type=item_display,tag=AW.AnnounceLine,distance=..200]
+    kill @e[type=item_display,tag=AW.AnnounceLineEven,distance=..200]
+    kill @e[type=marker,tag=AW.Marker.SummonPoint,distance=..200]
+
+# 継承元の処理
+    function asset:mob/super.remove

--- a/Asset/data/asset/functions/mob/0393.labyria_first/remove/.mcfunction
+++ b/Asset/data/asset/functions/mob/0393.labyria_first/remove/.mcfunction
@@ -1,0 +1,14 @@
+#> asset:mob/0393.labyria_first/remove/
+#
+# 天使が居なくなる際に実行される処理
+#
+# @within asset:mob/alias/393/remove
+
+# モデル削除
+    function animated_java:labyria/remove/all
+
+# マーカーキル
+    kill @e[type=marker,tag=AX.Marker.SummonPoint,distance=..200]
+
+# 継承元の処理
+    function asset:mob/super.remove

--- a/Asset/data/asset/functions/mob/alias/391/remove.mcfunction
+++ b/Asset/data/asset/functions/mob/alias/391/remove.mcfunction
@@ -1,0 +1,8 @@
+#> asset:mob/alias/391/remove
+#
+# Remove処理のエイリアス
+#
+# @within asset_manager:mob/remove/remove.m
+
+# 元のInit処理を呼び出す
+    function asset:mob/0391.axia_first/remove/

--- a/Asset/data/asset/functions/mob/alias/392/remove.mcfunction
+++ b/Asset/data/asset/functions/mob/alias/392/remove.mcfunction
@@ -1,0 +1,8 @@
+#> asset:mob/alias/392/remove
+#
+# Remove処理のエイリアス
+#
+# @within asset_manager:mob/remove/remove.m
+
+# 元のInit処理を呼び出す
+    function asset:mob/0392.ecual_first/remove/

--- a/Asset/data/asset/functions/mob/alias/393/remove.mcfunction
+++ b/Asset/data/asset/functions/mob/alias/393/remove.mcfunction
@@ -1,0 +1,8 @@
+#> asset:mob/alias/393/remove
+#
+# Remove処理のエイリアス
+#
+# @within asset_manager:mob/remove/remove.m
+
+# 元のInit処理を呼び出す
+    function asset:mob/0393.labyria_first/remove/


### PR DESCRIPTION
プレイヤーが途中で死んだときに発生する、マーカー残留バグを修正