### PR TITLE
🧑‍💻 [Object 5] 重力飛翔体抽象の処理を修正

### DIFF
--- a/Asset/data/asset/functions/artifact/1272.big_water_launcher/trigger/3.main.mcfunction
+++ b/Asset/data/asset/functions/artifact/1272.big_water_launcher/trigger/3.main.mcfunction
@@ -18,7 +18,7 @@
 # ダメージ設定
     execute store result storage api: Argument.FieldOverride.Damage int 1 run random value 1150..1650
 # 飛距離設定
-    data modify storage api: Argument.FieldOverride.Speed set value 1
+    data modify storage api: Argument.FieldOverride.Motion set value 1
     execute store result storage api: Argument.FieldOverride.UserID int 1 run scoreboard players get @s UserID
     data modify storage api: Argument.FieldOverride.AdditionalMPHeal set from storage api: PersistentArgument.AdditionalMPHeal
     execute anchored eyes positioned ^ ^ ^1 run function api:object/summon

--- a/Asset/data/asset/functions/object/0005.abstract_gravity_projectile/init/.mcfunction
+++ b/Asset/data/asset/functions/object/0005.abstract_gravity_projectile/init/.mcfunction
@@ -4,5 +4,9 @@
 #
 # @within asset:object/alias/5/init
 
+# モーション
+    data modify storage lib: Argument.VectorMagnitude set from storage asset:context this.Motion
+    execute on vehicle run function lib:motion/
+
 # ダメージを与えて描画更新
     execute on vehicle run damage @s 0

--- a/Asset/data/asset/functions/object/0005.abstract_gravity_projectile/register.mcfunction
+++ b/Asset/data/asset/functions/object/0005.abstract_gravity_projectile/register.mcfunction
@@ -17,4 +17,4 @@
 # ID (int)
     data modify storage asset:object ID set value 5
 # フィールド(オプション)
-    # data modify storage asset:object Field.myValue set value
+    data modify storage asset:object Field.Motion set value 1f

--- a/Asset/data/asset/functions/object/1141.big_water_balloon/init/.mcfunction
+++ b/Asset/data/asset/functions/object/1141.big_water_balloon/init/.mcfunction
@@ -23,8 +23,8 @@
     tag @e[type=item_display,tag=Init,sort=nearest,limit=1] remove Init
 
 # Motionで射出
-    data modify storage lib: Argument.VectorMagnitude set from storage asset:context this.Speed
-    execute on vehicle at @s run function lib:motion/
+    #data modify storage lib: Argument.VectorMagnitude set from storage asset:context this.Speed
+    #execute on vehicle at @s run function lib:motion/
 
 # Super
     function asset:object/super.init


### PR DESCRIPTION
Motion前提なんだから抽象のinitでmotion実行してもええやろの気持ちで変えた