### PR TITLE
🩹 [Mob 219, 220] 大動脈 & 大静脈に固有デスログを追加

### DIFF
--- a/Asset/data/asset/functions/mob/0219.aorta/attack/.mcfunction
+++ b/Asset/data/asset/functions/mob/0219.aorta/attack/.mcfunction
@@ -15,6 +15,8 @@
 # ダメージ
     data modify storage api: Argument.Damage set value 41f
     data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.DeathMessage append value '[{"translate": "%1$sは%2$sによって心臓が600BPMを目指してしまった","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]'
+    data modify storage api: Argument.DeathMessage append value '[{"translate": "%1$sは%2$sによって脈が限界を超えてしまった","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]'
     function api:damage/modifier
     execute as @p[tag=Victim,distance=..6] run function api:damage/
     function api:damage/reset

--- a/Asset/data/asset/functions/mob/0219.aorta/attack/.mcfunction
+++ b/Asset/data/asset/functions/mob/0219.aorta/attack/.mcfunction
@@ -13,7 +13,7 @@
     execute at @p[tag=Victim,distance=..6] run playsound block.conduit.ambient hostile @a ~ ~ ~ 0.8 1.5 0
 
 # ダメージ
-    data modify storage api: Argument.Damage set value 41f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.DeathMessage append value '[{"translate": "%1$sは%2$sによって心臓が600BPMを目指してしまった","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]'
     data modify storage api: Argument.DeathMessage append value '[{"translate": "%1$sは%2$sによって脈が限界を超えてしまった","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]'

--- a/Asset/data/asset/functions/mob/0219.aorta/register.mcfunction
+++ b/Asset/data/asset/functions/mob/0219.aorta/register.mcfunction
@@ -65,4 +65,4 @@
         data modify storage asset:mob Resist.Thunder set value 0.8
 
 # フィールド
-    # data modify storage asset:mob Field set value {}
+    data modify storage asset:mob Field.Damage set value 41f

--- a/Asset/data/asset/functions/mob/0220.vena_cana/attack/.mcfunction
+++ b/Asset/data/asset/functions/mob/0220.vena_cana/attack/.mcfunction
@@ -14,6 +14,8 @@
 # ダメージ
     data modify storage api: Argument.Damage set value 41f
     data modify storage api: Argument.AttackType set value "Physical"
+    data modify storage api: Argument.DeathMessage append value '[{"translate": "%1$sは%2$sによって鎮静化された","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]'
+    data modify storage api: Argument.DeathMessage append value '[{"translate": "%1$sは%2$sによって脈が止まってしまった","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]'
     function api:damage/modifier
     execute as @p[tag=Victim,distance=..6] run function api:damage/
     function api:damage/reset

--- a/Asset/data/asset/functions/mob/0220.vena_cana/attack/.mcfunction
+++ b/Asset/data/asset/functions/mob/0220.vena_cana/attack/.mcfunction
@@ -12,7 +12,7 @@
     execute at @p[tag=Victim,distance=..6] run particle dust 0.149 0.682 0.741 1 ~ ~1.2 ~ 0.6 0.3 0.6 0 30 normal @a
 
 # ダメージ
-    data modify storage api: Argument.Damage set value 41f
+    data modify storage api: Argument.Damage set from storage asset:context this.Damage
     data modify storage api: Argument.AttackType set value "Physical"
     data modify storage api: Argument.DeathMessage append value '[{"translate": "%1$sは%2$sによって鎮静化された","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]'
     data modify storage api: Argument.DeathMessage append value '[{"translate": "%1$sは%2$sによって脈が止まってしまった","with":[{"selector":"@s"},{"nbt":"Return.AttackerName","storage":"lib:","interpret":true}]}]'

--- a/Asset/data/asset/functions/mob/0220.vena_cana/register.mcfunction
+++ b/Asset/data/asset/functions/mob/0220.vena_cana/register.mcfunction
@@ -54,3 +54,6 @@
         data modify storage asset:mob Resist.Water set value 0.8
     # 雷倍率 (float) (オプション)
         data modify storage asset:mob Resist.Thunder set value 1.1
+
+# フィールド
+    data modify storage asset:mob Field.Damage set value 41f


### PR DESCRIPTION
FIx #1684
ついでにダメージ定義をregisterにするなど