### PR TITLE
✨ [Trader 9] 建材商人の取引にソウルサンド、マグマブロックを追加

### DIFF
--- a/Asset/data/asset/functions/trader/1/register.mcfunction
+++ b/Asset/data/asset/functions/trader/1/register.mcfunction
@@ -70,12 +70,3 @@ execute unless loaded 27 15 -29 run return 1
     data modify storage asset:trader Trades[-1].BuyA set value {PresetItem:"currency/",Count:6b}
     data modify storage asset:trader Trades[-1].Sell set value {id:"minecraft:name_tag",Count:1b}
 
-# 取引 マグマブロック
-    data modify storage asset:trader Trades append value {}
-    data modify storage asset:trader Trades[-1].BuyA set value {PresetItem:"currency/",Count:1b}
-    data modify storage asset:trader Trades[-1].Sell set value {id:"minecraft:magma_block",Count:8b}
-
-# 取引 ソウルサンド
-    data modify storage asset:trader Trades append value {}
-    data modify storage asset:trader Trades[-1].BuyA set value {PresetItem:"currency/",Count:1b}
-    data modify storage asset:trader Trades[-1].Sell set value {id:"minecraft:soul_sand",Count:8b}

--- a/Asset/data/asset/functions/trader/9/register.mcfunction
+++ b/Asset/data/asset/functions/trader/9/register.mcfunction
@@ -105,6 +105,16 @@ execute unless loaded 38 21 -70 run return 1
     data modify storage asset:trader Trades[-1].BuyA set value {PresetItem:"currency/",Count:1b}
     data modify storage asset:trader Trades[-1].Sell set value {id:"minecraft:shroomlight",Count:2b}
 
+# 取引 マグマブロック
+    data modify storage asset:trader Trades append value {}
+    data modify storage asset:trader Trades[-1].BuyA set value {PresetItem:"currency/",Count:1b}
+    data modify storage asset:trader Trades[-1].Sell set value {id:"minecraft:magma_block",Count:8b}
+
+# 取引 ソウルサンド
+    data modify storage asset:trader Trades append value {}
+    data modify storage asset:trader Trades[-1].BuyA set value {PresetItem:"currency/",Count:1b}
+    data modify storage asset:trader Trades[-1].Sell set value {id:"minecraft:soul_sand",Count:8b}
+
 # 取引 オークの苗木をトウヒの苗木に
     data modify storage asset:trader Trades append value {}
     data modify storage asset:trader Trades[-1].BuyA set value {id:"oak_sapling",Count:1b}


### PR DESCRIPTION
Fix #1736 
