### PR TITLE
🐛 [Mob 437] 無法の鉄巨人がプレイヤーが自身より下にいる際に降りてこない問題を修正

### DIFF
--- a/Asset/data/asset/functions/mob/0437.lawless_iron_doll/tick/base_move/common/descend_when_all_player_below.mcfunction
+++ b/Asset/data/asset/functions/mob/0437.lawless_iron_doll/tick/base_move/common/descend_when_all_player_below.mcfunction
@@ -1,0 +1,8 @@
+#> asset:mob/0437.lawless_iron_doll/tick/base_move/common/descend_when_all_player_below
+#
+# 全てのプレイヤーが下にいるなら降りる
+#
+# @within function asset:mob/0437.lawless_iron_doll/tick/base_move/**
+
+# 周囲のプレイヤーが上にいない && 下が当たり判定のないブロックなら降りる
+    execute if entity @s[tag=!C5.Moveset.Intro] at @p[gamemode=!spectator,distance=..256] positioned ~-50 ~-1 ~-50 unless entity @s[dx=99,dy=-50,dz=99] at @s if block ~ ~-0.25 ~ #lib:no_collision/ run tp @s ~ ~-0.25 ~

--- a/Asset/data/asset/functions/mob/0437.lawless_iron_doll/tick/base_move/skill/breathing_walk/walk_tick.mcfunction
+++ b/Asset/data/asset/functions/mob/0437.lawless_iron_doll/tick/base_move/skill/breathing_walk/walk_tick.mcfunction
@@ -26,7 +26,7 @@
     scoreboard players reset $Interval Temporary
 
 # そこらのプレイヤーより上にいる場合、下にTP。下にブロックがあったら止まるよ。
-    execute if entity @s[tag=!C5.Moveset.Intro] at @p[gamemode=!spectator,distance=..256] positioned ~-50 ~-1 ~-50 unless entity @s[dx=99,dy=-50,dz=99] at @s if block ~ ~-0.25 ~ #lib:no_collision run tp @s ~ ~-0.25 ~
+    function asset:mob/0437.lawless_iron_doll/tick/base_move/common/descend_when_all_player_below
 
 # 足元が埋まっていて、上にブロックがないなら上に移動
     execute unless block ^ ^ ^1 #lib:no_collision run tp @s ~ ~0.1 ~

--- a/Asset/data/asset/functions/mob/0437.lawless_iron_doll/tick/base_move/skill/charge/charge_tick.mcfunction
+++ b/Asset/data/asset/functions/mob/0437.lawless_iron_doll/tick/base_move/skill/charge/charge_tick.mcfunction
@@ -49,7 +49,7 @@
     execute if block ~ ~-0.25 ~ #lib:no_collision run particle minecraft:enchant ~ ~ ~ 0.7 0 0.7 0 30 force @a[distance=..32]
 
 # そこらのプレイヤーより上にいる場合、下にTP。下にブロックがあったら止まるよ。
-    execute if entity @s[tag=!C5.Moveset.Intro] at @p[gamemode=!spectator,distance=..256] positioned ~-50 ~-1 ~-50 unless entity @s[dx=99,dy=-50,dz=99] at @s if block ~ ~-0.25 ~ #lib:no_collision run tp @s ~ ~-0.25 ~
+    function asset:mob/0437.lawless_iron_doll/tick/base_move/common/descend_when_all_player_below
 
 # 足元の先が埋まっているなら、上に移動
     execute rotated ~ 0 unless block ^ ^ ^1 #lib:no_collision run tp @s ~ ~0.1 ~

--- a/Asset/data/asset/functions/mob/0437.lawless_iron_doll/tick/base_move/walk/tick.mcfunction
+++ b/Asset/data/asset/functions/mob/0437.lawless_iron_doll/tick/base_move/walk/tick.mcfunction
@@ -29,7 +29,7 @@
     scoreboard players reset $Interval Temporary
 
 # そこらのプレイヤーより上にいる場合、下にTP。下にブロックがあったら止まるよ。
-    execute if entity @s[tag=!C5.Moveset.Intro] at @p[gamemode=!spectator,distance=..256] positioned ~-50 ~-1 ~-50 unless entity @s[dx=99,dy=-50,dz=99] at @s if block ~ ~-0.25 ~ #lib:no_collision run tp @s ~ ~-0.25 ~
+    function asset:mob/0437.lawless_iron_doll/tick/base_move/common/descend_when_all_player_below
 
 # 足元の先が埋まっているなら、上に移動
     execute rotated ~ 0 unless block ^ ^ ^1 #lib:no_collision run tp @s ~ ~0.1 ~


### PR DESCRIPTION
敗因: tagを直すことだけに夢中になり動作検証を忘れたこと

鉄巨人は歩きモーションをスキルとして実行しているが、その歩きモーション実行時にはC5.InActionが付与されている。それなのに降下する処理で「該当tagが付与されていないとき」を指定しているため降りられなかった

今まではtagの指定ミスにより常時判定に成功していたとみられる