### PR TITLE
🐛 [Artifact 860] えんじぇるうぃんぐを砥石で使用できない様に

### DIFF
--- a/Asset/data/asset/functions/artifact/0860.angel_wing/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0860.angel_wing/give/2.give.mcfunction
@@ -58,7 +58,7 @@
 # 扱える神 (string[]) Wikiを参照
     data modify storage asset:artifact CanUsedGod set value ["Flora", "Nyaptov", "Rumor"]
 # カスタムNBT (NBTCompound) 追加で指定したいNBT (オプション)
-    data modify storage asset:artifact CustomNBT set value {HideFlags:4,Unbreakable:1b,Damage:432,Enchantments:[{}],AttributeModifiers:[{AttributeName:"generic.armor",Name:"generic.armor",Amount:4,Operation:0,UUID:[I;-841939162,-2040575447,-1620123908,-865268967],Slot:"chest"},{AttributeName:"generic.armor_toughness",Name:"generic.armor_toughness",Amount:0.5,Operation:0,UUID:[I;-1577191449,583288319,-1475995532,-1239126169],Slot:"chest"}]}
+    data modify storage asset:artifact CustomNBT set value {HideFlags:4,Unbreakable:1b,Damage:432,AttributeModifiers:[{AttributeName:"generic.armor",Name:"generic.armor",Amount:4,Operation:0,UUID:[I;-841939162,-2040575447,-1620123908,-865268967],Slot:"chest"},{AttributeName:"generic.armor_toughness",Name:"generic.armor_toughness",Amount:0.5,Operation:0,UUID:[I;-1577191449,583288319,-1475995532,-1239126169],Slot:"chest"}]}
 
 # 神器の入手用function
     function asset:artifact/common/give


### PR DESCRIPTION
そもそもクリエイティブを使用せずに、えんじぇるうぃんぐを飛ぶことのできる不可壊エリトラにする方法はこちらの検証では確認できなかったが……念の為、砥石で使えないようにしておく。

またこのままだと普通のエリトラと見分けがつかないので、テクスチャを新たに実装すべきかもしれない。