### PR TITLE
🐛 [Artifact 566 - 569] 大賢者装備の好感度がフルセット解除時に強制的に0になる問題を修正

### DIFF
--- a/Asset/data/asset/functions/effect/0256.the_great_sage_s_attire/fullset/dis_equip.mcfunction
+++ b/Asset/data/asset/functions/effect/0256.the_great_sage_s_attire/fullset/dis_equip.mcfunction
@@ -29,7 +29,7 @@
 
 # 好感度・時間の修正
     scoreboard players remove @s FQ.Favorability 1
-    scoreboard players operation @s FQ.Favorability < $0 Const
+    scoreboard players operation @s FQ.Favorability > $0 Const
     scoreboard players reset @s FQ.TalkTime
 
 # リセット


### PR DESCRIPTION
多分バグっぽく見えるので