### PR TITLE
🚸 [Artifact 125] ストームボウのダメージ表記を修正

### DIFF
--- a/Asset/data/asset/functions/artifact/0125.storm_bow/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0125.storm_bow/give/2.give.mcfunction
@@ -29,7 +29,7 @@
 # 神器の発動条件 (TextComponentString) (オプション)
     # data modify storage asset:artifact Condition set value
 # 攻撃に関する情報 -Damage量 (literal[]/literal) Wikiを参照 (オプション)
-    data modify storage asset:artifact AttackInfo.Damage set value [6,30]
+    data modify storage asset:artifact AttackInfo.Damage set value "6x5"
 # 攻撃に関する情報 -攻撃タイプ (string[]) Wikiを参照 (オプション)
     data modify storage asset:artifact AttackInfo.AttackType set value [Physical]
 # 攻撃に関する情報 -攻撃属性 (string[]) Wikiを参照 (オプション)


### PR DESCRIPTION
Fix #1957 