### PR TITLE
⬆️ actions を Node.js 24 に対応

### DIFF
--- a/.github/workflows/datapack-linter.yml
+++ b/.github/workflows/datapack-linter.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/