### PR TITLE
🩹 [Artifact 248] 異形の森の弓のエンチャントを削除

### DIFF
--- a/Asset/data/asset/functions/artifact/0248.bow_of_vinderre/give/2.give.mcfunction
+++ b/Asset/data/asset/functions/artifact/0248.bow_of_vinderre/give/2.give.mcfunction
@@ -60,7 +60,7 @@
 # 扱える神 (string[]) Wikiを参照
     data modify storage asset:artifact CanUsedGod set value ["Flora", "Urban", "Wi-ki", "Rumor"]
 # カスタムNBT (NBTCompound) 追加で指定したいNBT (オプション)
-    data modify storage asset:artifact CustomNBT set value {HideFlags:5,Enchantments:[{id:"minecraft:power",lvl:6s}]}
+    # data modify storage asset:artifact CustomNBT set value
 
 # 神器の入手用function
     function asset:artifact/common/give


### PR DESCRIPTION
テクスチャ適用につきもう不要と判断