### PR TITLE
🐛 [Artifact 248] 異形の森の弓の毒ダメージが付与時に即発動する問題を修正

### DIFF
--- a/Asset/data/asset/functions/effect/0279.poison_of_vinderre/register.mcfunction
+++ b/Asset/data/asset/functions/effect/0279.poison_of_vinderre/register.mcfunction
@@ -36,4 +36,5 @@
     data modify storage asset:effect StackVisible set value false
 
 # フィールド
+    data modify storage asset:effect Field.Tick set value 20
     # data modify storage asset:effect Field.UserID set value

--- a/Asset/data/asset/functions/object/1070.arrow_of_vinderre/recursive/.mcfunction
+++ b/Asset/data/asset/functions/object/1070.arrow_of_vinderre/recursive/.mcfunction
@@ -1,0 +1,9 @@
+#> asset:object/1070.arrow_of_vinderre/recursive/
+#
+# 継承先などから実行される処理
+#
+# @within asset:object/alias/1070/recursive
+
+#
+    particle dust 0.412 0.588 0.506 0.7 ^ ^ ^ 0 0 0 0 1 normal @a
+    particle dust 0.412 0.588 0.506 0.7 ^ ^ ^-0.25 0 0 0 0 1 normal @a

--- a/Asset/data/asset/functions/object/alias/1070/recursive.mcfunction
+++ b/Asset/data/asset/functions/object/alias/1070/recursive.mcfunction
@@ -1,0 +1,8 @@
+#> asset:object/alias/1070/recursive
+#
+# メソッド処理のエイリアス
+#
+# @within asset_manager:object/call_method/run_method.m
+
+# 元のメソッド処理を呼び出す
+    function asset:object/1070.arrow_of_vinderre/recursive/


### PR DESCRIPTION
Fix #2065