### PR TITLE
🐛 @within の記述漏れ 8 件を修正

### DIFF
--- a/Asset/data/asset/functions/mob/0078.messenger_of_thunder/tick/skill/predict_thunder/predict_point2.mcfunction
+++ b/Asset/data/asset/functions/mob/0078.messenger_of_thunder/tick/skill/predict_thunder/predict_point2.mcfunction
@@ -2,7 +2,7 @@
 #
 # 偏差の処理2
 #
-# @within function asset:mob/0078.messenger_of_thunder/tick/skill/predict_thunder/3.predict_point1.m
+# @within function asset:mob/0078.messenger_of_thunder/tick/skill/predict_thunder/predict_point1.m
 
 # AECを召喚して拡散するを5回繰り返す
 # それぞれ起爆までの時間をそれぞれ設定する

--- a/Asset/data/asset/functions/mob/0373.gold_coffin/_index.d.mcfunction
+++ b/Asset/data/asset/functions/mob/0373.gold_coffin/_index.d.mcfunction
@@ -1,6 +1,0 @@
-#> asset:mob/0373.gold_coffin/_index.d
-# @private
-
-#> tag
-# @within function asset:mob/0373.gold_coffin/**
-    #declare tag

--- a/Asset/data/asset/functions/mob/0410.heiloang/tick/event/sweep/attack.mcfunction
+++ b/Asset/data/asset/functions/mob/0410.heiloang/tick/event/sweep/attack.mcfunction
@@ -2,7 +2,7 @@
 #
 # なぎはらい火炎放射
 #
-# @within function asset:mob/0410.heiloang/tick/event/sweep/attack
+# @within function asset:mob/0410.heiloang/tick/event/sweep/get_attack_position.m
 
 # 演出
     particle explosion ~ ~ ~ 1 1 1 0 1 force

--- a/Asset/data/asset/functions/mob/0411.behemoth/remove/kill_hitbox.mcfunction
+++ b/Asset/data/asset/functions/mob/0411.behemoth/remove/kill_hitbox.mcfunction
@@ -2,7 +2,7 @@
 #
 # Mobの死亡時の処理
 #
-# @within function asset:mob/0411.behemoth/death/kill_hitbox
+# @within function asset:mob/0411.behemoth/remove/**
 
 # 当たり判定消去
     execute if entity @s[type=slime] run data merge entity @s {Size:0,Tags:["BF.Temp.Dummy"]}

--- a/Asset/data/asset/functions/mob/0411.behemoth/tick/event/terzetto_purgatorio/attack_check_hit.mcfunction
+++ b/Asset/data/asset/functions/mob/0411.behemoth/tick/event/terzetto_purgatorio/attack_check_hit.mcfunction
@@ -2,7 +2,7 @@
 #
 # テルツェット・ディザスター
 #
-# @within asset:mob/0411.behemoth/tick/event/terzetto_purgatorio/attack
+# @within function asset:mob/0411.behemoth/tick/event/terzetto_purgatorio/attack.m
 
 # 氷柱確認
     scoreboard players set @s BF.Counter 80

--- a/Asset/data/asset/functions/mob/0411.behemoth/tick/event/terzetto_purgatorio/prediction_line_obj.mcfunction
+++ b/Asset/data/asset/functions/mob/0411.behemoth/tick/event/terzetto_purgatorio/prediction_line_obj.mcfunction
@@ -2,7 +2,7 @@
 #
 # テルツェット・プルガトリオ
 #
-# @within asset:mob/0411.behemoth/tick/event/terzetto_purgatorio/
+# @within function asset:mob/0411.behemoth/tick/event/terzetto_purgatorio/**
 
 # 対象決定
     tag @e[type=item_display,tag=2181.Line,tag=!2181.Line.End,sort=random,limit=1] add BF.Temp.Dummy

--- a/Asset/data/asset/functions/object/1042.mini_black_hole_flying/tick/vfx/particle.mcfunction
+++ b/Asset/data/asset/functions/object/1042.mini_black_hole_flying/tick/vfx/particle.mcfunction
@@ -2,7 +2,7 @@
 #
 # vfx
 #
-# @within function asset:object/1042.mini_black_hole_flying/tick/flying/vfx/
+# @within function asset:object/1042.mini_black_hole_flying/tick/vfx/**
 
 # 円
     particle dust -1 0 -1 1.25 ^-0.0 ^0.0 ^0.5 0.0 0.0 0.0 0.0 1 force @a[distance=..64]

--- a/Asset/data/asset/functions/object/1086.lightning_exploit/hit/vfx/particle.mcfunction
+++ b/Asset/data/asset/functions/object/1086.lightning_exploit/hit/vfx/particle.mcfunction
@@ -2,7 +2,7 @@
 #
 #
 #
-# @within function asset:object/1086.lightning_exploit/hit/vfx/random
+# @within function asset:object/1086.lightning_exploit/hit/vfx/random.m
 
 # [ImportKey]: NobwRALgngDgpmAXGAxgSwE4oDYIDRgCuhaAJkmAIykCslcATAGwBGAtEwwwBxsAsfAGYBONsOaC2KSgENSABhGCAzAHZKwsAQB2MgLYJkgMMUABJS1gYMjPoDOScCgD2hbRCRN5BFHDdwMDmAAbjLYhIbgAB5IXmBQMQC+CQQ2pGiE9ojKAHQ0BLYQ1u6IsXDY2GgwtoaU8rEYToUQhrFotgCi5ZXV7QCOhKHYUADKVj7kiIKh1UkAukA_3
 # 円 1

--- a/Asset/data/asset/functions/object/2221.aurora_scaffold/tick/break/process/do.mcfunction
+++ b/Asset/data/asset/functions/object/2221.aurora_scaffold/tick/break/process/do.mcfunction
@@ -2,7 +2,7 @@
 #
 #
 #
-# @within function asset:object/2221.aurora_scaffold/tick/break/process/
+# @within function asset:object/2221.aurora_scaffold/tick/break/process/**
 
 #> Private
 # @private


### PR DESCRIPTION
## 概要

`@within` の記述漏れ 8 件 を修正

## 主な変更点

| # | file | 種別 |
|---|---|---|
| 1 | `.../predict_thunder/predict_point2.mcfunction` | typo (`3.` prefix) |
| 2 | `.../heiloang/tick/event/sweep/attack.mcfunction` | 自己参照 → 実 caller |
| 3 | `.../behemoth/remove/kill_hitbox.mcfunction` | rename 漏れ (`death/` 残骸) |
| 4 | `.../terzetto_purgatorio/attack_check_hit.mcfunction` | 拡張子違い (`.m` 欠) + `function` keyword 追加 |
| 5 | `.../terzetto_purgatorio/prediction_line_obj.mcfunction` | dir 表記に `**` glob 追加 + `function` keyword 追加 |
| 6 | `.../mini_black_hole_flying/tick/vfx/particle.mcfunction` | path rename 漏れ (`flying/` 残骸) |
| 7 | `.../lightning_exploit/hit/vfx/particle.mcfunction` | 拡張子違い (`.m` 欠) |
| 8 | `.../aurora_scaffold/tick/break/process/do.mcfunction` | dir 表記に `**` glob 追加 |
